### PR TITLE
CircleCI Cache Fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,31 +8,36 @@ executors:
 
 # reusable command for all jobs
 commands:
-  checkout_from_cache:
-    description: 'To checkout and restore the dependencies cache'
+  checkout_from_workspace:
+    description: 'To checkout and attach the workspace'
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - dependency-cache-{{ checksum "package.json" }}
-            - dependency-cache-
+      - attach_workspace:
+          at: ~/webex-components
 
 # define jobs
 jobs:
   install:
     executor: main-executor
     steps:
-      - checkout_from_cache
+      - checkout
+      - restore_cache:
+          keys:
+            - dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install Dependencies
-          command: npm ci
+          command: npm i
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
           paths: node_modules
+      - persist_to_workspace:
+          root: .
+          paths: node_modules
+
   test:
     executor: main-executor
     steps:
-      - checkout_from_cache
+      - checkout_from_workspace
       - run:
           name: Linting
           command: npm run test:eslint
@@ -41,24 +46,28 @@ jobs:
           command: npm run test:coverage
       - store_test_results:
           path: test_results
+
   build:
     executor: main-executor
     steps:
-      - checkout_from_cache
+      - checkout_from_workspace
       - run:
-          name: build
+          name: Build
           command: npm run build
+      - persist_to_workspace:
+          root: .
+          paths: dist
+
   release:
     executor: main-executor
     steps:
-      - checkout_from_cache
+      - checkout_from_workspace
       - run:
-          name: release
+          name: Release
           command: npm run release
 
 # execute the jobs in a orderly manner
 workflows:
-  version: 2
   setup_test_release:
     jobs:
       - install


### PR DESCRIPTION
So I installed our components library and noticed that our `dist` directory is not downloaded into the directory. in our previous PR we had to separate our `build` job from `release` job in case of blocking the release if the build job had failed. after that change, I noticed that the `dist` directory is not included to the `release` job, which makes sense. We did not add the `dist` directory anywhere to be included to the next job which is a release job. So I decided to use `workspace` to persist the data (node_modules from the `install` job + dist directory from the `build` job) between the jobs. This actually turned out to be a better performant process, since we are not unarchiving the whole repo for each job anymore. and only apply the `node_modules` - 63 MB layer to all jobs and `dist` - 1.3 MB layer to `release` job. this will definitely pay off in the future as our repo keeps getting larger. Let me know if you have anymore questions.


## How to test

comment out the workflows rules and you should be able to view all the jobs behavioral details. `npm run release` does not publish on a non-master branch. so you could leave the code as is

## Example
I thought [this](https://circleci.com/workflow-run/6f0a749a-3b7b-4940-aa39-f50d2b0e4a17) was a good example of our workflow. don't mind the workflow order. our flow right now is as follows:

install -> test -> build -> release