### PR TITLE
Webex Local Media styles based on container width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19181,15 +19181,15 @@
       }
     },
     "sass-loader": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.3.1.tgz",
-      "integrity": "sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
+      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
-        "loader-utils": "^1.0.1",
-        "neo-async": "^2.5.0",
-        "pify": "^4.0.1",
+        "loader-utils": "^1.2.3",
+        "neo-async": "^2.6.1",
+        "schema-utils": "^2.6.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -19204,11 +19204,15 @@
             "shallow-clone": "^3.0.0"
           }
         },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
+        "schema-utils": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
         },
         "semver": {
           "version": "6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,6 +1688,11 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@juggle/resize-observer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.0.2.tgz",
+      "integrity": "sha512-9fEfZIxZ1qTahMSX50pigfSJ/1N6X2oABhmgd4Dt2SsPkZi0lTlvoHu5V2yrGZ6m+oALfS4tJrpx9nbVIxwOYQ=="
+    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-scss": "^1.0.2",
     "rxjs": "^6.5.4",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^8.0.2",
     "sass-resources-loader": "^2.0.1",
     "semantic-release": "^15.13.19",
     "style-loader": "^0.23.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rxjs": "^6.5.4"
   },
   "dependencies": {
+    "@juggle/resize-observer": "^3.0.2",
     "@momentum-ui/react": "^23.2.1",
     "@webex/component-adapter-interfaces": "^1.9.0",
     "date-fns": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "classnames": "^2.2.6",
     "conventional-changelog-angular": "^5.0.3",
     "css-loader": "^3.1.0",
     "enzyme": "^3.10.0",

--- a/src/components/WebexLocalMedia/README.md
+++ b/src/components/WebexLocalMedia/README.md
@@ -16,15 +16,15 @@ To see all the different possible states of the Webex Local Media component, you
 
 ## Embed
 
-1.  Create a component adapter from which the data will be retrieved (See [adapters](../../adapters)). For instance:
+1. Create a component adapter from which the data will be retrieved (See [adapters](../../adapters)). For instance:
 
     ```js
     const jsonAdapter = new WebexJSONAdapter(jsonData);
     ```
 
-2.  Create a component instance by passing the person ID as a string and
-    enclose it within [a data provider](../WebexDataProvider/WebexDataProvider.js)
-    that takes the [component data adapter](../../adapters/WebexJSONAdapter.js) that we created previously
+2. Create a component instance by passing the person ID as a string and enclose it within
+[a data provider](../WebexDataProvider/WebexDataProvider.js) that takes
+the [component data adapter](../../adapters/WebexJSONAdapter.js) that we created previously
 
     ```js
     <WebexDataProvider adapter={jsonAdapter}>
@@ -32,4 +32,5 @@ To see all the different possible states of the Webex Local Media component, you
     </WebexDataProvider>
     ```
 
-The component knows how to manage its data. If anything changes in the data source that the adapter manages, the component will also update on its own.
+The component knows how to manage its data. If anything changes in the data source that the adapter manages,
+the component will also update on its own.

--- a/src/components/WebexLocalMedia/WebexLocalMedia.js
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import {Spinner} from '@momentum-ui/react';
 
 import {WebexAvatar} from '../';
-import {useMe, useMeeting, useStream} from '../hooks';
+import {useElementDimensions, useMe, useMeeting, useStream} from '../hooks';
 
 import './WebexLocalMedia.scss';
 
@@ -15,18 +15,24 @@ import './WebexLocalMedia.scss';
  * @returns {Object} JSX of the component
  */
 export default function WebexLocalMedia({meetingID}) {
+  const [mediaRef, {width}] = useElementDimensions();
   const {localVideo} = useMeeting(meetingID);
   const {ID} = useMe();
   const videoRef = useStream(localVideo);
 
   const cssClasses = classNames({
     'local-media': true,
+    'local-media-desktop': width >= 425, // Standard large phone width
     'no-media': localVideo === null,
   });
 
   const disabledVideo = ID ? <WebexAvatar personID={ID} displayStatus={false} /> : <Spinner />;
 
-  return <div className={cssClasses}>{localVideo ? <video ref={videoRef} playsInline autoPlay /> : disabledVideo}</div>;
+  return (
+    <div ref={mediaRef} className={cssClasses}>
+      {localVideo ? <video ref={videoRef} playsInline autoPlay /> : disabledVideo}
+    </div>
+  );
 }
 
 WebexLocalMedia.propTypes = {

--- a/src/components/WebexLocalMedia/WebexLocalMedia.js
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import {Spinner} from '@momentum-ui/react';
 
 import {WebexAvatar} from '../';
@@ -17,11 +18,15 @@ export default function WebexLocalMedia({meetingID}) {
   const {localVideo} = useMeeting(meetingID);
   const {ID} = useMe();
   const videoRef = useStream(localVideo);
+
+  const cssClasses = classNames({
+    'local-media': true,
+    'no-media': localVideo === null,
+  });
+
   const disabledVideo = ID ? <WebexAvatar personID={ID} displayStatus={false} /> : <Spinner />;
 
-  return (
-    <div className="local-media">{localVideo ? <video ref={videoRef} playsInline autoPlay /> : disabledVideo}</div>
-  );
+  return <div className={cssClasses}>{localVideo ? <video ref={videoRef} playsInline autoPlay /> : disabledVideo}</div>;
 }
 
 WebexLocalMedia.propTypes = {

--- a/src/components/WebexLocalMedia/WebexLocalMedia.js
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.js
@@ -8,10 +8,10 @@ import {useMe, useMeeting, useStream} from '../hooks';
 import './WebexLocalMedia.scss';
 
 /**
- * Webex Local Media component displays the user's local video
+ * Webex Local Media component displays the user's local video.
  *
- * @param {object} props
- * @returns {object} JSX of the component
+ * @param {string} props.meetingID  ID of the meeting from which to obtain local media
+ * @returns {Object} JSX of the component
  */
 export default function WebexLocalMedia({meetingID}) {
   const {localVideo} = useMeeting(meetingID);

--- a/src/components/WebexLocalMedia/WebexLocalMedia.scss
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.scss
@@ -5,6 +5,8 @@
 
   height: 100%;
   width: 100%;
+  min-height: 7.5rem; // Smallest height for local media is the tallest an avatar can get through transforms
+  min-width: 7.5rem; // Smallest width for local media is the widest an avatar can get through transforms
 
   background: black;
 
@@ -14,8 +16,14 @@
   }
 
   .md-avatar {
-    width: 6.25rem !important;
-    height: 6.25rem !important;
+    transform: scale(2); // Avatar is 40x40px, this makes it 80x80px
+    transform-origin: center center;
+  }
+
+  &-desktop {
+    .md-avatar {
+      transform: scale(3); // Avatar is 40x40px, this makes it 120x120px
+    }
   }
 }
 

--- a/src/components/WebexLocalMedia/WebexLocalMedia.scss
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.scss
@@ -2,16 +2,23 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
   height: 100%;
   width: 100%;
+
+  background: black;
+
+  video {
+    height: 100%;
+    width: 100%;
+  }
+
+  .md-avatar {
+    width: 6.25rem !important;
+    height: 6.25rem !important;
+  }
 }
 
-.local-media video {
-  width: 100%;
-  height: 100%;
-}
-
-.local-media .md-avatar {
-  width: 6.25rem !important;
-  height: 6.25rem !important;
+.no-media {
+  background: white;
 }

--- a/src/components/WebexLocalMedia/WebexLocalMedia.stories.js
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.stories.js
@@ -5,23 +5,17 @@ import jsonData from '../../data';
 import {WebexJSONAdapter} from '../../adapters';
 import {WebexLocalMedia, WebexDataProvider} from '../';
 
-// Setup for the stories
 const stories = storiesOf('Webex Local Media', module);
 const webexAdapter = new WebexJSONAdapter(jsonData);
-const wrapperStyle = {height: '500px', width: '800px', border: '1px solid black'};
 
 stories.add('enabled', () => (
-  <div style={wrapperStyle}>
-    <WebexDataProvider adapter={webexAdapter}>
-      <WebexLocalMedia meetingID="localVideo" personID="default" />
-    </WebexDataProvider>
-  </div>
+  <WebexDataProvider adapter={webexAdapter}>
+    <WebexLocalMedia meetingID="localVideo" />
+  </WebexDataProvider>
 ));
 
 stories.add('disabled', () => (
-  <div style={wrapperStyle}>
-    <WebexDataProvider adapter={webexAdapter}>
-      <WebexLocalMedia meetingID="scheduledMeeting" personID="default" />
-    </WebexDataProvider>
-  </div>
+  <WebexDataProvider adapter={webexAdapter}>
+    <WebexLocalMedia meetingID="noMedia" />
+  </WebexDataProvider>
 ));

--- a/src/components/WebexLocalMedia/WebexLocalMedia.test.js
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.test.js
@@ -13,7 +13,7 @@ describe('Webex Local Media component', () => {
     });
 
     test('matches snapshot of disabled local video', () => {
-      expect(shallow(<WebexLocalMedia meetingID="scheduledMeeting" />)).toMatchSnapshot();
+      expect(shallow(<WebexLocalMedia meetingID="noMedia" />)).toMatchSnapshot();
     });
   });
 });

--- a/src/components/WebexLocalMedia/__snapshots__/WebexLocalMedia.test.js.snap
+++ b/src/components/WebexLocalMedia/__snapshots__/WebexLocalMedia.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Webex Local Media component snapshot matches snapshot of disabled local video 1`] = `
 <div
-  className="local-media"
+  className="local-media no-media"
 >
   <WebexAvatar
     displayStatus={false}

--- a/src/components/hooks/index.js
+++ b/src/components/hooks/index.js
@@ -1,6 +1,7 @@
 export {default as useActivity} from './useActivity';
 export {default as useActivityScroll} from './useActivityScroll';
 export {default as useActivityStream} from './useActivityStream';
+export {default as useElementDimensions} from './useElementDimensions';
 export {default as useMe} from './useMe';
 export {default as useMeeting} from './useMeeting';
 export {default as useMeetingDestination} from './useMeetingDestination';

--- a/src/components/hooks/useElementDimensions.js
+++ b/src/components/hooks/useElementDimensions.js
@@ -1,0 +1,43 @@
+import {useEffect, useRef, useState} from 'react';
+import {ResizeObserver as Polyfill} from '@juggle/resize-observer';
+
+/**
+ * Custom hook that returns an element reference and the dimensions of the
+ * element it refers to.
+ *
+ * @returns {Array} Element reference and dimensions in pixels
+ */
+export default function useElementDimensions() {
+  const elementRef = useRef({});
+  const [height, setHeight] = useState(0);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    // Use native implementation when available, otherwise use polyfill
+    const ResizeObserver = window.ResizeObserver || Polyfill;
+    const observer = new ResizeObserver((entries) => {
+      // Get the first DOM element (our ref) and look at the border box dimensions
+      const [entry] = entries;
+      const {contentRect} = entry;
+
+      // Update height only if there has been height change
+      if (height !== contentRect.height) {
+        setHeight(contentRect.height);
+      }
+
+      // Update width only if there has been width change
+      if (width !== contentRect.width) {
+        setWidth(contentRect.width);
+      }
+    });
+
+    observer.observe(elementRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return [elementRef, {height, width}];
+}

--- a/src/data/meetings.json
+++ b/src/data/meetings.json
@@ -2,6 +2,16 @@
   "loadingMeeting": {
     "ID": null
   },
+  "noMedia": {
+    "ID": "noMedia",
+    "title": "Meeting with no Media",
+    "localVideo": null,
+    "remoteVideo": null,
+    "localAudio": null,
+    "remoteAudio": null,
+    "localShare": null,
+    "remoteShare": null
+  },
   "scheduledMeeting": {
     "ID": "scheduledMeeting",
     "title": "Our Scheduled Meeting",


### PR DESCRIPTION
This a version that relies on the size on the container based on the [Resize Observable API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).

Replaces https://github.com/webex/components/pull/81, which is based on media queries (which look at the window, not the container).