### PR TITLE
docs(readme): fix storybook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ aimed at react developers that want to embed the components into their applicati
 
 ## Demo
 
-We use [Storybook](https://storybook.js.org) to showcase all supported components. Our Storybook can be found at https://webex.github.io/components/storybook.
+We use [Storybook](https://storybook.js.org) to showcase all supported components. Our Storybook can be found at https://webex.github.io/components/storybook/.
 
 ## Install
 


### PR DESCRIPTION
The scope of the changes in this pull request is to fix the link in the root readme file to properly link to the storybook.