### PR TITLE
Container styling encapsulation

### DIFF
--- a/src/components/WebexInMeeting/WebexInMeeting.js
+++ b/src/components/WebexInMeeting/WebexInMeeting.js
@@ -18,19 +18,17 @@ import './WebexInMeeting.scss';
  */
 export default function WebexInMeeting({meetingID}) {
   const [meetingRef, {width}] = useElementDimensions();
-  const classBaseName = 'in-meeting';
-  const classObjects = {};
-
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-${classBaseName}`] = true;
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-${classBaseName}-tablet`] = width >= TABLET && width < DESKTOP;
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-${classBaseName}-desktop`] = width >= DESKTOP;
-
-  const cssClasses = classNames(classObjects);
+  const classBaseName = `${WEBEX_COMPONENTS_CLASS_PREFIX}-in-meeting`;
+  const mainClasses = {
+    [`${classBaseName}`]: true,
+    [`${classBaseName}-tablet`]: width >= TABLET && width < DESKTOP,
+    [`${classBaseName}-desktop`]: width >= DESKTOP,
+  };
 
   return (
-    <div ref={meetingRef} className={cssClasses}>
-      <WebexRemoteMedia meetingID={meetingID} />
-      <WebexLocalMedia meetingID={meetingID} />
+    <div ref={meetingRef} className={classNames(mainClasses)}>
+      <WebexRemoteMedia className="remote-media-in-meeting" meetingID={meetingID} />
+      <WebexLocalMedia className="local-media-in-meeting" meetingID={meetingID} />
     </div>
   );
 }

--- a/src/components/WebexInMeeting/WebexInMeeting.scss
+++ b/src/components/WebexInMeeting/WebexInMeeting.scss
@@ -12,13 +12,13 @@ $shadow-color: rgba(0, 0, 0, 0.2);
 
   background: black;
 
-  .remote-media {
+  .remote-media-in-meeting {
     position: relative;
     height: 100%;
     width: 100%;
   }
 
-  .local-media {
+  .local-media-in-meeting {
     position: absolute;
     top: 1rem;
     bottom: auto;

--- a/src/components/WebexInMeeting/__snapshots__/WebexInMeeting.test.js.snap
+++ b/src/components/WebexInMeeting/__snapshots__/WebexInMeeting.test.js.snap
@@ -5,9 +5,11 @@ exports[`Webex InMeeting component snapshot matches snapshot of meeting 1`] = `
   className="wxc-in-meeting"
 >
   <WebexRemoteMedia
+    className="remote-media-in-meeting"
     meetingID="remoteMedia"
   />
   <WebexLocalMedia
+    className="local-media-in-meeting"
     meetingID="remoteMedia"
   />
 </div>

--- a/src/components/WebexInterstitialMeeting/WebexInterstitialMeeting.js
+++ b/src/components/WebexInterstitialMeeting/WebexInterstitialMeeting.js
@@ -20,7 +20,7 @@ export default function WebexInterstitialMeeting({meetingID}) {
     <div className={`${WEBEX_COMPONENTS_CLASS_PREFIX}-interstitial-meeting`}>
       {meetingID ? (
         <React.Fragment>
-          <WebexMeetingInfo meetingID={meetingID} />
+          <WebexMeetingInfo className="interstitial-meeting-info" meetingID={meetingID} />
           <WebexLocalMedia meetingID={meetingID} />
         </React.Fragment>
       ) : (

--- a/src/components/WebexInterstitialMeeting/WebexInterstitialMeeting.scss
+++ b/src/components/WebexInterstitialMeeting/WebexInterstitialMeeting.scss
@@ -8,7 +8,7 @@
   width: 100%;
   height: 100%;
 
-  .meeting-info {
+  .interstitial-meeting-info {
     position: absolute;
     align-self: flex-start;
     width: 100%;

--- a/src/components/WebexInterstitialMeeting/__snapshots__/WebexInterstitialMeeting.test.js.snap
+++ b/src/components/WebexInterstitialMeeting/__snapshots__/WebexInterstitialMeeting.test.js.snap
@@ -20,9 +20,11 @@ exports[`Webex Interstitial Meeting component snapshot matches snapshot of meeti
   className="wxc-interstitial-meeting"
 >
   <WebexMeetingInfo
+    className="interstitial-meeting-info"
     meetingID="localMedia"
   />
   <WebexLocalMedia
+    className=""
     meetingID="localMedia"
   />
 </div>

--- a/src/components/WebexLocalMedia/WebexLocalMedia.js
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.js
@@ -16,30 +16,33 @@ import './WebexLocalMedia.scss';
  * @param {string} props.meetingID  ID of the meeting from which to obtain local media
  * @returns {Object} JSX of the component
  */
-export default function WebexLocalMedia({meetingID}) {
+export default function WebexLocalMedia({className, meetingID}) {
   const [mediaRef, {width}] = useElementDimensions();
   const {localVideo} = useMeeting(meetingID);
   const {ID} = useMe();
   const videoRef = useStream(localVideo);
 
-  const classBaseName = 'local-media';
-  const classObjects = {};
-
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-${classBaseName}`] = true;
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-${classBaseName}-desktop`] = width >= PHONE_LARGE;
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-no-media`] = localVideo === null;
-
-  const cssClasses = classNames(classObjects);
-
+  const classBaseName = `${WEBEX_COMPONENTS_CLASS_PREFIX}-local-media`;
+  const mainClasses = {
+    [classBaseName]: true,
+    [`${classBaseName}-desktop`]: width >= PHONE_LARGE,
+    [`${classBaseName}-no-media`]: localVideo === null,
+    [className]: !!className,
+  };
   const disabledVideo = ID ? <WebexAvatar personID={ID} displayStatus={false} /> : <Spinner />;
 
   return (
-    <div ref={mediaRef} className={cssClasses}>
+    <div ref={mediaRef} className={classNames(mainClasses)}>
       {localVideo ? <video ref={videoRef} playsInline autoPlay /> : disabledVideo}
     </div>
   );
 }
 
 WebexLocalMedia.propTypes = {
+  className: PropTypes.string,
   meetingID: PropTypes.string.isRequired,
+};
+
+WebexLocalMedia.defaultProps = {
+  className: '',
 };

--- a/src/components/WebexLocalMedia/WebexLocalMedia.scss
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.scss
@@ -27,8 +27,8 @@
       transform: scale(3); // Avatar is 40x40px, this makes it 120x120px
     }
   }
-}
 
-.#{$WEBEX_COMPONENTS_CLASS_PREFIX}-no-media {
-  background: white;
+  &-no-media {
+    background: white;
+  }
 }

--- a/src/components/WebexLocalMedia/WebexLocalMedia.test.js
+++ b/src/components/WebexLocalMedia/WebexLocalMedia.test.js
@@ -15,5 +15,9 @@ describe('Webex Local Media component', () => {
     test('matches snapshot of disabled local video', () => {
       expect(shallow(<WebexLocalMedia meetingID="noMedia" />)).toMatchSnapshot();
     });
+
+    test('matches snapshot of local video with custom CSS class', () => {
+      expect(shallow(<WebexLocalMedia className="my-custom-class" meetingID="noMedia" />)).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/WebexLocalMedia/__snapshots__/WebexLocalMedia.test.js.snap
+++ b/src/components/WebexLocalMedia/__snapshots__/WebexLocalMedia.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Webex Local Media component snapshot matches snapshot of disabled local video 1`] = `
 <div
-  className="wxc-local-media wxc-no-media"
+  className="wxc-local-media wxc-local-media-no-media"
 >
   <WebexAvatar
     displayStatus={false}
@@ -18,6 +18,17 @@ exports[`Webex Local Media component snapshot matches snapshot of local video 1`
   <video
     autoPlay={true}
     playsInline={true}
+  />
+</div>
+`;
+
+exports[`Webex Local Media component snapshot matches snapshot of local video with custom CSS class 1`] = `
+<div
+  className="wxc-local-media wxc-local-media-no-media my-custom-class"
+>
+  <WebexAvatar
+    displayStatus={false}
+    personID="default"
   />
 </div>
 `;

--- a/src/components/WebexMeeting/WebexMeeting.js
+++ b/src/components/WebexMeeting/WebexMeeting.js
@@ -21,22 +21,22 @@ export default function WebexMeeting({meetingDestination, controls}) {
   const {ID, remoteVideo} = useMeetingDestination(meetingDestination);
   const isActive = remoteVideo !== null;
 
-  const classBaseName = 'meeting';
-  const classObjects = {};
-
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-${classBaseName}`] = true;
-  classObjects[`${WEBEX_COMPONENTS_CLASS_PREFIX}-${classBaseName}-active`] = ID && isActive;
-
-  const cssClasses = classNames(classObjects);
+  const classBaseName = `${WEBEX_COMPONENTS_CLASS_PREFIX}-meeting`;
+  const mainClasses = {
+    [classBaseName]: true,
+    [`${classBaseName}-active`]: ID && isActive,
+  };
 
   const meetingControls = controls(isActive).map((key) => <WebexMeetingControl key={key} type={key} />);
 
   return (
-    <div className={cssClasses}>
+    <div className={classNames(mainClasses)}>
       {ID ? (
         <Fragment>
           {isActive ? <WebexInMeeting meetingID={ID} /> : <WebexInterstitialMeeting meetingID={ID} />}
-          <WebexMeetingControls meetingID={ID}>{meetingControls}</WebexMeetingControls>
+          <WebexMeetingControls className="meeting-controls-container" meetingID={ID}>
+            {meetingControls}
+          </WebexMeetingControls>
         </Fragment>
       ) : (
         <Spinner />

--- a/src/components/WebexMeeting/WebexMeeting.scss
+++ b/src/components/WebexMeeting/WebexMeeting.scss
@@ -12,19 +12,11 @@
   min-height: 25rem;
   min-width: 20rem; // Standard small phone width
 
-  .meeting-controls {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
+  .meeting-controls-container {
     position: absolute;
     bottom: 2rem;
 
     z-index: 100; // Arbitrary large number
-
-    > * {
-      margin: 0.3125rem;
-    }
   }
 
   &-active  {

--- a/src/components/WebexMeeting/__snapshots__/WebexMeeting.test.js.snap
+++ b/src/components/WebexMeeting/__snapshots__/WebexMeeting.test.js.snap
@@ -8,6 +8,7 @@ exports[`Webex Meeting component snapshot matches snapshot of a user that has jo
     meetingID="remoteMedia"
   />
   <WebexMeetingControls
+    className="meeting-controls-container"
     meetingID="remoteMedia"
   >
     <WebexMeetingControl
@@ -34,6 +35,7 @@ exports[`Webex Meeting component snapshot matches snapshot of a user that has jo
     meetingID="remoteMedia"
   />
   <WebexMeetingControls
+    className="meeting-controls-container"
     meetingID="remoteMedia"
   >
     <WebexMeetingControl
@@ -52,6 +54,7 @@ exports[`Webex Meeting component snapshot matches snapshot of a user waiting to 
     meetingID="localMedia"
   />
   <WebexMeetingControls
+    className="meeting-controls-container"
     meetingID="localMedia"
   >
     <WebexMeetingControl
@@ -78,6 +81,7 @@ exports[`Webex Meeting component snapshot matches snapshot of a user waiting to 
     meetingID="localMedia"
   />
   <WebexMeetingControls
+    className="meeting-controls-container"
     meetingID="localMedia"
   >
     <WebexMeetingControl

--- a/src/components/WebexMeetingControl/WebexMeetingControls.js
+++ b/src/components/WebexMeetingControl/WebexMeetingControls.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import {WEBEX_COMPONENTS_CLASS_PREFIX} from '../../constants';
+
+import './WebexMeetingControls.scss';
 
 export const MeetingContext = React.createContext();
 
@@ -10,15 +15,25 @@ export const MeetingContext = React.createContext();
  * @param {object} props
  * @returns {object} JSX of the component
  */
-export default function WebexMeetingControls({meetingID, children}) {
+export default function WebexMeetingControls({children, className, meetingID}) {
+  const mainClasses = {
+    [`${WEBEX_COMPONENTS_CLASS_PREFIX}-meeting-controls`]: true,
+    [className]: !!className,
+  };
+
   return (
     <MeetingContext.Provider value={meetingID}>
-      <div className="meeting-controls">{children}</div>
+      <div className={classNames(mainClasses)}>{children}</div>
     </MeetingContext.Provider>
   );
 }
 
 WebexMeetingControls.propTypes = {
-  meetingID: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  meetingID: PropTypes.string.isRequired,
+};
+
+WebexMeetingControls.defaultProps = {
+  className: '',
 };

--- a/src/components/WebexMeetingControl/WebexMeetingControls.scss
+++ b/src/components/WebexMeetingControl/WebexMeetingControls.scss
@@ -1,0 +1,11 @@
+@import '../../styles/variables';
+
+.#{$WEBEX_COMPONENTS_CLASS_PREFIX}-meeting-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  > * {
+    margin: 0.3125rem;
+  }
+}

--- a/src/components/WebexMeetingControl/WebexMeetingControls.test.js
+++ b/src/components/WebexMeetingControl/WebexMeetingControls.test.js
@@ -4,9 +4,18 @@ import WebexMeetingControls from './WebexMeetingControls';
 
 describe('Webex Meeting Controls component', () => {
   test('matches snapshot', () => {
-    const meetingID = 'my-meeting';
     const component = shallow(
-      <WebexMeetingControls meetingID={meetingID}>
+      <WebexMeetingControls meetingID="my-meeting">
+        <div className="test" />
+      </WebexMeetingControls>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('matches snapshot with custom CSS class', () => {
+    const component = shallow(
+      <WebexMeetingControls className="my-custom-class" meetingID="my-meeting">
         <div className="test" />
       </WebexMeetingControls>
     );

--- a/src/components/WebexMeetingControl/__snapshots__/WebexMeetingControls.test.js.snap
+++ b/src/components/WebexMeetingControl/__snapshots__/WebexMeetingControls.test.js.snap
@@ -5,7 +5,21 @@ exports[`Webex Meeting Controls component matches snapshot 1`] = `
   value="my-meeting"
 >
   <div
-    className="meeting-controls"
+    className="wxc-meeting-controls"
+  >
+    <div
+      className="test"
+    />
+  </div>
+</ContextProvider>
+`;
+
+exports[`Webex Meeting Controls component matches snapshot with custom CSS class 1`] = `
+<ContextProvider
+  value="my-meeting"
+>
+  <div
+    className="wxc-meeting-controls my-custom-class"
   >
     <div
       className="test"

--- a/src/components/WebexMeetingInfo/WebexMeetingInfo.js
+++ b/src/components/WebexMeetingInfo/WebexMeetingInfo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import {format} from 'date-fns';
 import {Spinner} from '@momentum-ui/react';
 
@@ -31,9 +32,13 @@ export function formatMeetingTime(startDate, endDate) {
  * @param {object} props
  * @returns {object} JSX of the component
  */
-export default function WebexMeetingInfo({meetingID}) {
+export default function WebexMeetingInfo({className, meetingID}) {
   const {ID, startTime, endTime, title} = useMeeting(meetingID);
   let infoComponent;
+  const mainClasses = {
+    [`${WEBEX_COMPONENTS_CLASS_PREFIX}-meeting-info`]: true,
+    [className]: !!className,
+  };
 
   if (ID) {
     const meetingTime = startTime ? <h3>{formatMeetingTime(new Date(startTime), new Date(endTime))}</h3> : null;
@@ -53,9 +58,14 @@ export default function WebexMeetingInfo({meetingID}) {
     );
   }
 
-  return <div className={`${WEBEX_COMPONENTS_CLASS_PREFIX}-meeting-info`}>{infoComponent}</div>;
+  return <div className={classNames(mainClasses)}>{infoComponent}</div>;
 }
 
 WebexMeetingInfo.propTypes = {
+  className: PropTypes.string,
   meetingID: PropTypes.string.isRequired,
+};
+
+WebexMeetingInfo.defaultProps = {
+  className: '',
 };

--- a/src/components/WebexMeetingInfo/WebexMeetingInfo.test.js
+++ b/src/components/WebexMeetingInfo/WebexMeetingInfo.test.js
@@ -10,6 +10,10 @@ describe('Webex Meeting Info component', () => {
       expect(shallow(<WebexMeetingInfo meetingID="scheduledMeeting" />)).toMatchSnapshot();
     });
 
+    test('matches snapshot of scheduled meeting with custom CSS class', () => {
+      expect(shallow(<WebexMeetingInfo className="my-custom-class" meetingID="scheduledMeeting" />)).toMatchSnapshot();
+    });
+
     test('matches snapshot of one on one meeting', () => {
       expect(shallow(<WebexMeetingInfo meetingID="oneOnOneMeeting" />)).toMatchSnapshot();
     });

--- a/src/components/WebexMeetingInfo/__snapshots__/WebexMeetingInfo.test.js.snap
+++ b/src/components/WebexMeetingInfo/__snapshots__/WebexMeetingInfo.test.js.snap
@@ -45,6 +45,16 @@ exports[`Webex Meeting Info component snapshot matches snapshot of scheduled mee
 </div>
 `;
 
+exports[`Webex Meeting Info component snapshot matches snapshot of scheduled meeting with custom CSS class 1`] = `
+<div
+  className="wxc-meeting-info my-custom-class"
+>
+  <h2>
+    Our Scheduled Meeting
+  </h2>
+</div>
+`;
+
 exports[`Webex Meeting Info component snapshot matches snapshot of space meeting 1`] = `
 <div
   className="wxc-meeting-info"

--- a/src/components/WebexRemoteMedia/WebexRemoteMedia.js
+++ b/src/components/WebexRemoteMedia/WebexRemoteMedia.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import {Badge, Spinner, AlertBanner} from '@momentum-ui/react';
 
 import {WEBEX_COMPONENTS_CLASS_PREFIX} from '../../constants';
@@ -15,14 +16,18 @@ import './WebexRemoteMedia.scss';
  *
  * NOTE: waiting for the UX for a design on what to display if there is no remote video
  */
-export default function WebexRemoteMedia({meetingID}) {
+export default function WebexRemoteMedia({className, meetingID}) {
   const {remoteAudio, remoteVideo, error} = useMeeting(meetingID);
   const audioRef = useStream(remoteAudio);
   const videoRef = useStream(remoteVideo);
   const hasMedia = !!(remoteAudio || remoteVideo);
+  const mainClasses = {
+    [`${WEBEX_COMPONENTS_CLASS_PREFIX}-remote-media`]: true,
+    [className]: !!className,
+  };
 
   return (
-    <div className={`${WEBEX_COMPONENTS_CLASS_PREFIX}-remote-media`}>
+    <div className={classNames(mainClasses)}>
       {error ? (
         <AlertBanner show type="warning">
           Having trouble joining the meeting? Please check your connection.
@@ -44,5 +49,10 @@ export default function WebexRemoteMedia({meetingID}) {
 }
 
 WebexRemoteMedia.propTypes = {
+  className: PropTypes.string,
   meetingID: PropTypes.string.isRequired,
+};
+
+WebexRemoteMedia.defaultProps = {
+  className: '',
 };

--- a/src/components/WebexRemoteMedia/WebexRemoteMedia.test.js
+++ b/src/components/WebexRemoteMedia/WebexRemoteMedia.test.js
@@ -10,6 +10,7 @@ describe('Webex Remote Media component', () => {
     test('matches snapshot while loading', () => {
       expect(shallow(<WebexRemoteMedia meetingID="noMedia" />)).toMatchSnapshot();
     });
+
     test('matches snapshot of disabled remote audio', () => {
       expect(shallow(<WebexRemoteMedia meetingID="remoteVideo" />)).toMatchSnapshot();
     });
@@ -24,6 +25,10 @@ describe('Webex Remote Media component', () => {
 
     test('matches snapshot on error', () => {
       expect(shallow(<WebexRemoteMedia meetingID="failMeetingID" />)).toMatchSnapshot();
+    });
+
+    test('matches snapshot of enabled remote audio & video with custom CSS class', () => {
+      expect(shallow(<WebexRemoteMedia className="my-custom-class" meetingID="remoteAudio&Video" />)).toMatchSnapshot();
     });
   });
 });

--- a/src/components/WebexRemoteMedia/__snapshots__/WebexRemoteMedia.test.js.snap
+++ b/src/components/WebexRemoteMedia/__snapshots__/WebexRemoteMedia.test.js.snap
@@ -35,6 +35,20 @@ exports[`Webex Remote Media component snapshot matches snapshot of enabled remot
 </div>
 `;
 
+exports[`Webex Remote Media component snapshot matches snapshot of enabled remote audio & video with custom CSS class 1`] = `
+<div
+  className="wxc-remote-media my-custom-class"
+>
+  <video
+    autoPlay={true}
+    playsInline={true}
+  />
+  <audio
+    autoPlay={true}
+  />
+</div>
+`;
+
 exports[`Webex Remote Media component snapshot matches snapshot on error 1`] = `
 <div
   className="wxc-remote-media"


### PR DESCRIPTION
After merging #93 we discovered some issues due to expectation of child component classnames.

This PR limits the styles for each component and creates new "container" elements that the parent component styles for layout of the child component only.

One example of the issue this fixes is the usage of the `WebexLocalMedia` component within the `WebexInMeeting` component. The in meeting component was attempting to position the local media component with the class name "remote-media" that comes from the child component. This causes an interdependency between the components and requires strings to be updated in multiple places. 