### PR TITLE
build(codeowners): add all files under core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@webex/js-sdk-widgets-core
+*  @webex/js-sdk-widgets-core


### PR DESCRIPTION
Fixes incorrect CODEOWNERS file from https://github.com/webex/components/pull/96.