### PR TITLE
fix(hooks): cloned members before setting state

### DIFF
--- a/src/components/hooks/useParticipants.js
+++ b/src/components/hooks/useParticipants.js
@@ -20,7 +20,7 @@ export default function useParticipants(membershipID) {
       console.error(error.message);
     };
     const onMembers = (data) => {
-      setParticipants(data.members);
+      setParticipants([...data.members]);
     };
 
     const subscription = membershipsAdapter.getMembers(membershipID).subscribe(onMembers, onError);


### PR DESCRIPTION
`useParticipants` hook makes a shallow copy the `members` array of a membership. Without sending a new object, React does not detect that there has been a change to the participant list.

Bug tracked by [SPARK-158264](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-158264)