### PR TITLE
fix(roster): add key property to WebexParticipant

### DIFF
--- a/src/components/WebexParticipantRoster/WebexParticipantRoster.js
+++ b/src/components/WebexParticipantRoster/WebexParticipantRoster.js
@@ -15,7 +15,9 @@ import useParticipants from '../hooks/useParticipants';
 export default function WebexParticipantRoster({destination}) {
   const participants = useParticipants(destination);
 
-  const participantList = participants.map((participant) => <WebexParticipant personID={participant.personID} />);
+  const participantList = participants.map((participant) => (
+    <WebexParticipant key={participant.personID} personID={participant.personID} />
+  ));
 
   return <List>{participantList}</List>;
 }


### PR DESCRIPTION
It's a 1 liner PR to fix a bug that the dynamic components (generated from loops) should come with a key property.
JIRA:
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-158618