### PR TITLE
refactor(hooks): rename useParticipants to useMemberships

### DIFF
--- a/src/components/WebexParticipantRoster/WebexParticipantRoster.jsx
+++ b/src/components/WebexParticipantRoster/WebexParticipantRoster.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {List} from '@momentum-ui/react';
 
 import WebexParticipant from '../WebexParticipant/WebexParticipant';
-import useParticipants from '../hooks/useParticipants';
+import useMemberships from '../hooks/useMemberships';
 
 /**
  * Displays the roster of Webex meeting or room participants.
@@ -13,7 +13,7 @@ import useParticipants from '../hooks/useParticipants';
  * @returns {object} JSX of the component
  */
 export default function WebexParticipantRoster({destination}) {
-  const participants = useParticipants(destination);
+  const participants = useMemberships(destination);
 
   const participantList = participants.map((participant) => (
     <WebexParticipant key={participant.personID} personID={participant.personID} />

--- a/src/components/hooks/__mocks__/useMemberships.js
+++ b/src/components/hooks/__mocks__/useMemberships.js
@@ -1,6 +1,6 @@
 import {useContext} from 'react';
 
-export default function useParticipants(membershipID) {
+export default function useMemberships(membershipID) {
   const datasource = useContext();
   let participants = {...datasource.membershipsAdapter[membershipID]};
 

--- a/src/components/hooks/index.js
+++ b/src/components/hooks/index.js
@@ -8,6 +8,7 @@ export {default as useMe} from './useMe';
 export {default as useMeeting} from './useMeeting';
 export {default as useMeetingDestination} from './useMeetingDestination';
 export {default as useMeetingControl} from './useMeetingControl';
+export {default as useMemberships} from './useMemberships';
 export {default as usePerson} from './usePerson';
 export {default as useOverflowActivities} from './useOverflowActivities';
 export {default as useRoom} from './useRoom';

--- a/src/components/hooks/useMemberships.js
+++ b/src/components/hooks/useMemberships.js
@@ -10,24 +10,24 @@ import {AdapterContext} from './contexts';
  */
 
 /**
- * Custom hook that returns a list of participant IDs given a membership ID.
+ * Custom hook that returns a list of member IDs given a membership ID.
  *
- * @param {string} membershipID  ID of the room/meeting that contains the participants
+ * @param {string} membershipID  ID of the room/meeting that contains the memberships
  * @returns {Array.<Person>} List of the person IDs from the participants
  */
-export default function useParticipants(membershipID) {
-  const [participants, setParticipants] = useState([]);
+export default function useMemberships(membershipID) {
+  const [members, setMembers] = useState([]);
   const {membershipsAdapter} = useContext(AdapterContext);
 
   useEffect(() => {
     const onError = (error) => {
-      setParticipants([]);
+      setMembers([]);
 
       // eslint-disable-next-line no-console
       console.error(error.message);
     };
     const onMembers = (data) => {
-      setParticipants([...data.members]);
+      setMembers([...data.members]);
     };
 
     const subscription = membershipsAdapter.getMembers(membershipID).subscribe(onMembers, onError);
@@ -37,5 +37,5 @@ export default function useParticipants(membershipID) {
     };
   }, [membershipsAdapter, membershipID]);
 
-  return participants;
+  return members;
 }


### PR DESCRIPTION
Refactoring the `useParticipants` hook to more closely align with the naming of the membership adapter.