### PR TITLE
Momentum UI as peer dependency of UMD bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In your `index.js`, add the following imports:
 
 ```js
 import '@momentum-ui/core/css/momentum-ui.min.css';
-import '@webex/components/dist/webex-components.css';
+import '@webex/components/dist/css/webex-components.css';
 
 ...
 ```
@@ -67,7 +67,7 @@ In the `<head>` of your `index.html`, add the following imports:
   ...
 
   <link rel="stylesheet" type="text/css" href="node_modules/@momentum-ui/core/css/momentum-ui.min.css" />
-  <link rel="stylesheet" type="text/css" href="node_modules/@webex/components/dist/webex-components.css" />
+  <link rel="stylesheet" type="text/css" href="node_modules/@webex/components/dist/css/webex-components.css" />
 </head>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4591,15 +4591,6 @@
         }
       }
     },
-    "@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.0.8"
-      }
-    },
     "@rollup/plugin-node-resolve": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
@@ -5890,6 +5881,25 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
+      "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
@@ -5946,6 +5956,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/minimist": {
@@ -8794,6 +8810,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
     },
     "colors": {
@@ -12828,6 +12850,17 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -17390,6 +17423,15 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
@@ -24747,6 +24789,121 @@
           "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
           "dev": true,
           "optional": true
+        }
+      }
+    },
+    "rollup-plugin-copy": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.3.0.tgz",
+      "integrity": "sha512-euDjCUSBXZa06nqnwCNADbkAcYDfzwowfZQkto9K/TFhiH+QG7I4PUsEMwM9tDgomGWJc//z7KLW8t+tZwxADA==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-plain-object": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+          "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8852,6 +8852,12 @@
       "integrity": "sha512-iH9YA35ccw94nx5244GVkpyC9eVTsL71jZz6iz5w6RIf79JLF2AsXHXq9p6Oaohyl3sx5qSMnGsWUDFIAfWL4w==",
       "dev": true
     },
+    "commenting": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commenting/-/commenting-1.1.0.tgz",
+      "integrity": "sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==",
+      "dev": true
+    },
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
@@ -18359,6 +18365,12 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+      "dev": true
+    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -22930,6 +22942,12 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "package-name-regex": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/package-name-regex/-/package-name-regex-1.0.8.tgz",
+      "integrity": "sha512-g3vB2J62dLqf4m50VM4tJUC4sixw3JB+Igd0cF3P/gJhAvmvsmFEV2eWZTeLbwfkKEWTf3+gwQ2C6JFFRxWHEQ==",
+      "dev": true
+    },
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -24907,6 +24925,51 @@
         }
       }
     },
+    "rollup-plugin-license": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-2.2.0.tgz",
+      "integrity": "sha512-xXb1vviEwlJMX+VGUSsglcMA/Rh9d2QzEm94awy4FlnsPqGrXoTYYGOR3UXR6gYIxiJFkr7qmkKF/NXfre/y8g==",
+      "dev": true,
+      "requires": {
+        "commenting": "1.1.0",
+        "glob": "7.1.6",
+        "lodash": "4.17.19",
+        "magic-string": "0.25.7",
+        "mkdirp": "1.0.4",
+        "moment": "2.27.0",
+        "package-name-regex": "1.0.8",
+        "spdx-expression-validate": "2.0.0",
+        "spdx-satisfies": "5.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
+    },
     "rollup-plugin-scss": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-2.6.0.tgz",
@@ -26409,6 +26472,17 @@
       "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
       "dev": true
     },
+    "spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -26435,11 +26509,37 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
+    "spdx-expression-validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-2.0.0.tgz",
+      "integrity": "sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "spdx-license-ids": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
+    },
+    "spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+      "dev": true
+    },
+    "spdx-satisfies": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.0.tgz",
+      "integrity": "sha512-/hGhwh20BeGmkA+P/lm06RvXD94JduwNxtx/oX3B5ClPt1/u/m5MCaDNo1tV3Y9laLkQr/NRde63b9lLMhlNfw==",
+      "dev": true,
+      "requires": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
     },
     "split": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.26.4",
     "rollup-plugin-copy": "^3.3.0",
+    "rollup-plugin-license": "^2.2.0",
     "rollup-plugin-scss": "^2.6.0",
     "rollup-plugin-terser": "^7.0.0",
     "rollup-plugin-visualizer": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@webex/components",
   "version": "1.42.3",
-  "browser": "dist/webex-components.umd.min.js",
-  "module": "dist/webex-components.es.min.js",
+  "browser": "dist/umd/webex-components.umd.min.js",
+  "unpkg": "dist/umd/webex-components.umd.min.js",
+  "module": "dist/es/webex-components.es.min.js",
   "scripts": {
     "build": "rollup -c",
     "linter": "eslint src/",
@@ -51,7 +52,6 @@
     "@commitlint/config-conventional": "^9.1.1",
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-commonjs": "^15.0.0",
-    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
@@ -77,6 +77,7 @@
     "node-sass": "~4.12.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.26.4",
+    "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-scss": "^2.6.0",
     "rollup-plugin-terser": "^7.0.0",
     "rollup-plugin-visualizer": "^4.1.0",
@@ -159,11 +160,11 @@
         {
           "assets": [
             {
-              "path": "dist/webex-components.es.min.js",
+              "path": "dist/es/webex-components.es.min.js",
               "label": "ECMAScript (ESM) minified bundle"
             },
             {
-              "path": "dist/webex-components.umd.min.js",
+              "path": "dist/umd/webex-components.umd.min.js",
               "label": "Universal Module Definition (UMD) minified bundle"
             }
           ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import copy from 'rollup-plugin-copy';
+import license from 'rollup-plugin-license';
 import scss from 'rollup-plugin-scss';
 import visualizer from 'rollup-plugin-visualizer';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
@@ -33,6 +34,14 @@ const plugins = [
     // Remove Webpack-style imports
     // Webpack-style imports are left in code because Storybook uses Webpack
     importer: (path) => ({file: path[0] === '~' ? path.slice(1) : path}),
+  }),
+  license({
+    banner: `
+    Webex Component System.
+    Copyright (c) <%= moment().format('YYYY') %> Cisco Systems, Inc and its affiliates.
+
+    This source code is licensed under the MIT license found in the LICENSE file in the root directory of this source tree.
+    `,
   }),
   copy({
     targets: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,15 @@
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json';
+import copy from 'rollup-plugin-copy';
 import scss from 'rollup-plugin-scss';
 import visualizer from 'rollup-plugin-visualizer';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import {terser} from 'rollup-plugin-terser';
 
-const modulePath = 'dist/webex-components';
+const moduleName = 'webex-components';
+const ESModulePath = `dist/es/${moduleName}`;
+const UMDModulePath = `dist/umd/${moduleName}`;
+
 const plugins = [
   nodeResolve({
     extensions: [
@@ -21,19 +24,56 @@ const plugins = [
     babelHelpers: 'runtime',
     exclude: 'node_modules/**',
   }),
+  scss({
+    output: `dist/css/${moduleName}.css`,
+    outputStyle: 'compressed',
+    failOnError: true,
+    // Search for Sass in third-party packages e.g. Momentum UI
+    includePaths: ['node_modules'],
+    // Remove Webpack-style imports
+    // Webpack-style imports are left in code because Storybook uses Webpack
+    importer: (path) => ({file: path[0] === '~' ? path.slice(1) : path}),
+  }),
+  copy({
+    targets: [
+      // Copying Momentum's core CSS since there is no hosted version
+      {
+        src: 'node_modules/@momentum-ui/core/css/momentum-ui.min.css',
+        dest: 'dist/css',
+      },
+    ],
+  }),
 ];
+
+// Peer dependencies to exclude from bundle
+const external = [
+  /^@momentum-ui/,
+  /^prop-types/,
+  /^react/,
+  /^rxjs/,
+];
+
+// UMD global/window names for peer dependencies
+const globals = {
+  '@momentum-ui/react': 'momentum-ui-react',
+  'prop-types': 'PropTypes',
+  react: 'React',
+  'react-dom': 'ReactDOM',
+  rxjs: 'rxjs',
+  'rxjs/operators': 'rxjs.operators',
+};
 
 export default [
   {
     input: 'src/index.js',
     output: [
       {
-        file: `${modulePath}.es.js`,
+        file: `${ESModulePath}.es.js`,
         format: 'es',
         sourcemap: true,
       },
       {
-        file: `${modulePath}.es.min.js`,
+        file: `${ESModulePath}.es.min.js`,
         format: 'es',
         sourcemap: true,
         plugins: [terser()],
@@ -41,16 +81,6 @@ export default [
     ],
     plugins: [
       ...plugins,
-      scss({
-        output: `${modulePath}.css`,
-        outputStyle: 'compressed',
-        failOnError: true,
-        // Search for Sass in third-party packages e.g. Momentum UI
-        includePaths: ['node_modules'],
-        // Remove Webpack-style imports
-        // Webpack-style imports are left in code because Storybook uses Webpack
-        importer: (path) => ({file: path[0] === '~' ? path.slice(1) : path}),
-      }),
       visualizer({
         filename: 'docs/bundle-analysis-esm.html',
         title: 'Webex Components Library ESM Bundle Analysis',
@@ -58,68 +88,35 @@ export default [
     ],
     external: [
       /^@babel\/runtime/,
-      /^@momentum-ui/,
-      /^prop-types/,
-      /^react/,
-      /^rxjs/,
+      ...external,
     ],
   },
   {
-    // TODO: Remove UMD entry point when there is a Momentum UI UMD bundle
-    input: 'src/index.umd.js',
+    input: 'src/index.js',
     output: [
       {
-        file: `${modulePath}.umd.js`,
+        file: `${UMDModulePath}.umd.js`,
         format: 'umd',
         sourcemap: true,
         name: 'WebexComponents',
-        globals: {
-          'prop-types': 'PropTypes',
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          rxjs: 'rxjs',
-          'rxjs/operators': 'rxjs.operators',
-        },
+        globals,
       },
       {
-        file: `${modulePath}.umd.min.js`,
+        file: `${UMDModulePath}.umd.min.js`,
         format: 'umd',
         sourcemap: true,
         name: 'WebexComponents',
-        globals: {
-          'prop-types': 'PropTypes',
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          rxjs: 'rxjs',
-          'rxjs/operators': 'rxjs.operators',
-        },
+        globals,
         plugins: [terser()],
       },
     ],
     plugins: [
       ...plugins,
-      // TODO: Remove JSON plugin when there is a Momentum UI UMD bundle
-      json(),
-      // TODO: Remove separate UMD CSS when there is a Momentum UI UMD bundle
-      scss({
-        output: `${modulePath}.umd.css`,
-        outputStyle: 'compressed',
-        failOnError: true,
-        // Search for Sass in third-party packages e.g. Momentum UI
-        includePaths: ['node_modules'],
-        // Remove Webpack-style imports
-        // Webpack-style imports are left in code because Storybook uses Webpack
-        importer: (path) => ({file: path[0] === '~' ? path.slice(1) : path}),
-      }),
       visualizer({
         filename: 'docs/bundle-analysis-umd.html',
         title: 'Webex Components Library UMD Bundle Analysis',
       }),
     ],
-    external: [
-      /^prop-types/,
-      /^react/,
-      /^rxjs/,
-    ],
+    external,
   },
 ];

--- a/src/adapters/index.js
+++ b/src/adapters/index.js
@@ -1,6 +1,6 @@
 export {default as WebexJSONAdapter} from './WebexJSONAdapter';
 export {default as ActivitiesJSONAdapter} from './ActivitiesJSONAdapter';
 export {default as MeetingsJSONAdapter} from './MeetingsJSONAdapter';
+export {default as MembershipJSONAdapter} from './MembershipJSONAdapter';
 export {default as PeopleJSONAdapter} from './PeopleJSONAdapter';
 export {default as RoomsJSONAdapter} from './RoomsJSONAdapter';
-export {default as MembershipJSONAdapter} from './MembershipJSONAdapter';

--- a/src/components/WebexParticipant/WebexParticipant.jsx
+++ b/src/components/WebexParticipant/WebexParticipant.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ListItem from '@momentum-ui/react/lib/ListItem';
+import {ListItem} from '@momentum-ui/react';
 
 import {usePerson} from '../hooks';
 import WebexAvatar from '../WebexAvatar/WebexAvatar';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 import './styles/index.scss';
 
-export * from './components';
+export {WebexJSONAdapter} from './adapters';
 export {WEBEX_COMPONENTS_CLASS_PREFIX} from './constants';
+
+export * from './components';

--- a/src/index.umd.js
+++ b/src/index.umd.js
@@ -1,5 +1,0 @@
-import './styles/index.scss';
-import './styles/momentum-ui.scss';
-
-export * from './components';
-export {WEBEX_COMPONENTS_CLASS_PREFIX} from './constants';


### PR DESCRIPTION
Momentum UI as peer dependency of UMD bundle. Momentum UI causes build issues with their Sass. It's pretty heavy too and found that there is an AMD package hosted in [unpkg](https://unpkg.com/browse/@momentum-ui/react).

Moving outside of our bundle for performance purposes, as it is also a x10 reduction in size for the components UMD bundle.
Momentum UI CSS is also moved to its own file (another x10 reduction in size).

Adding `unpkg` to `package.json` so Webex. Components can be hosted properly in [unpkg](https://unpkg.com).
Added back JSON adapter as part of the distribution, as it can be useful for quick testing.

![with-momentum](https://user-images.githubusercontent.com/6610308/91244362-013d4e80-e701-11ea-97ff-3e78f16d0eac.png)
![without-momentum](https://user-images.githubusercontent.com/6610308/91244370-04383f00-e701-11ea-949d-738e24a1661f.png)