### PR TITLE
fix(WebexRemoteMedia): move useStream usage to own component

### DIFF
--- a/src/components/WebexRemoteMedia/RemoteMediaDisplay.jsx
+++ b/src/components/WebexRemoteMedia/RemoteMediaDisplay.jsx
@@ -1,0 +1,42 @@
+/* eslint-disable jsx-a11y/media-has-caption, react/forbid-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {useStream} from '../hooks';
+
+/**
+ * Remote Media Display component displays the meeting's remote video and audio html elements
+ *
+ * @param {object} props
+ * @param {object} props.remoteAudio
+ * @param {object} props.remoteShare
+ * @param {object} props.remoteVideo
+ * @returns {object} JSX of the component
+ */
+export default function RemoteMediaDisplay({remoteAudio, remoteShare, remoteVideo}) {
+  const audioRef = useStream(remoteAudio);
+  const videoRef = useStream(remoteVideo);
+  const shareRef = useStream(remoteShare);
+
+  return (
+    <>
+      {remoteVideo ? <video ref={videoRef} playsInline autoPlay /> : null}
+
+      {remoteShare ? <video ref={shareRef} playsInline autoPlay /> : null}
+
+      {remoteAudio ? <audio ref={audioRef} autoPlay /> : null}
+    </>
+  );
+}
+
+RemoteMediaDisplay.propTypes = {
+  remoteAudio: PropTypes.object,
+  remoteShare: PropTypes.object,
+  remoteVideo: PropTypes.object,
+};
+
+RemoteMediaDisplay.defaultProps = {
+  remoteAudio: null,
+  remoteShare: null,
+  remoteVideo: null,
+};

--- a/src/components/WebexRemoteMedia/RemoteMediaDisplay.test.js
+++ b/src/components/WebexRemoteMedia/RemoteMediaDisplay.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import RemoteMediaDisplay from './RemoteMediaDisplay';
+
+jest.mock('../hooks/useStream');
+
+describe('Remote Media Display component', () => {
+  describe('snapshot', () => {
+    test('matches snapshot of empty component', () => {
+      expect(shallow(<RemoteMediaDisplay />)).toMatchSnapshot();
+    });
+
+    test('matches snapshot of remote audio', () => {
+      expect(shallow(<RemoteMediaDisplay remoteAudio={{}} />)).toMatchSnapshot();
+    });
+
+    test('matches snapshot of remote video', () => {
+      expect(shallow(<RemoteMediaDisplay remoteVideo={{}} />)).toMatchSnapshot();
+    });
+
+    test('matches snapshot of remote share', () => {
+      expect(shallow(<RemoteMediaDisplay remoteShare={{}} />)).toMatchSnapshot();
+    });
+
+    test('matches snapshot of remote audio and Video', () => {
+      expect(shallow(<RemoteMediaDisplay remoteAudio={{}} remoteVideo={{}} />)).toMatchSnapshot();
+    });
+
+    test('matches snapshot of remote audio, video, and share', () => {
+      expect(shallow(<RemoteMediaDisplay remoteAudio={{}} remoteVideo={{}} remoteShare={{}} />))
+        .toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/WebexRemoteMedia/WebexRemoteMedia.jsx
+++ b/src/components/WebexRemoteMedia/WebexRemoteMedia.jsx
@@ -5,7 +5,8 @@ import classNames from 'classnames';
 import {Badge, Spinner, AlertBanner} from '@momentum-ui/react';
 
 import {WEBEX_COMPONENTS_CLASS_PREFIX} from '../../constants';
-import {useMeeting, useMemberships, useStream} from '../hooks';
+import {useMeeting, useMemberships} from '../hooks';
+import RemoteMediaDisplay from './RemoteMediaDisplay';
 import './WebexRemoteMedia.scss';
 
 /**
@@ -26,9 +27,6 @@ export default function WebexRemoteMedia({className, meetingID}) {
     error,
   } = useMeeting(meetingID);
   const members = useMemberships(meetingID, 'meeting');
-  const audioRef = useStream(remoteAudio);
-  const videoRef = useStream(remoteVideo);
-  const shareRef = useStream(remoteShare);
   const hasOtherMembers = members.length > 1;
   const hasMedia = !!(remoteAudio || remoteVideo || remoteShare);
   const hasTwoMedia = remoteVideo && remoteShare;
@@ -47,13 +45,11 @@ export default function WebexRemoteMedia({className, meetingID}) {
     );
   } else if (hasMedia && hasOtherMembers) {
     remoteDisplay = (
-      <>
-        {remoteVideo ? <video ref={videoRef} playsInline autoPlay /> : null}
-
-        {remoteShare ? <video ref={shareRef} playsInline autoPlay /> : null}
-
-        {remoteAudio ? <audio ref={audioRef} autoPlay /> : null}
-      </>
+      <RemoteMediaDisplay
+        remoteAudio={remoteAudio}
+        remoteVideo={remoteVideo}
+        remoteShare={remoteShare}
+      />
     );
   } else if (hasMedia && !hasOtherMembers) {
     remoteDisplay = (

--- a/src/components/WebexRemoteMedia/__snapshots__/RemoteMediaDisplay.test.js.snap
+++ b/src/components/WebexRemoteMedia/__snapshots__/RemoteMediaDisplay.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Remote Media Display component snapshot matches snapshot of empty component 1`] = `<Fragment />`;
+
+exports[`Remote Media Display component snapshot matches snapshot of remote audio 1`] = `
+<Fragment>
+  <audio
+    autoPlay={true}
+  />
+</Fragment>
+`;
+
+exports[`Remote Media Display component snapshot matches snapshot of remote audio and Video 1`] = `
+<Fragment>
+  <video
+    autoPlay={true}
+    playsInline={true}
+  />
+  <audio
+    autoPlay={true}
+  />
+</Fragment>
+`;
+
+exports[`Remote Media Display component snapshot matches snapshot of remote audio, video, and share 1`] = `
+<Fragment>
+  <video
+    autoPlay={true}
+    playsInline={true}
+  />
+  <video
+    autoPlay={true}
+    playsInline={true}
+  />
+  <audio
+    autoPlay={true}
+  />
+</Fragment>
+`;
+
+exports[`Remote Media Display component snapshot matches snapshot of remote share 1`] = `
+<Fragment>
+  <video
+    autoPlay={true}
+    playsInline={true}
+  />
+</Fragment>
+`;
+
+exports[`Remote Media Display component snapshot matches snapshot of remote video 1`] = `
+<Fragment>
+  <video
+    autoPlay={true}
+    playsInline={true}
+  />
+</Fragment>
+`;

--- a/src/components/WebexRemoteMedia/__snapshots__/WebexRemoteMedia.test.js.snap
+++ b/src/components/WebexRemoteMedia/__snapshots__/WebexRemoteMedia.test.js.snap
@@ -4,9 +4,10 @@ exports[`Webex Remote Media component snapshot matches snapshot of disabled remo
 <div
   className="wxc-remote-media"
 >
-  <video
-    autoPlay={true}
-    playsInline={true}
+  <RemoteMediaDisplay
+    remoteAudio={null}
+    remoteShare={null}
+    remoteVideo={Object {}}
   />
 </div>
 `;
@@ -15,8 +16,10 @@ exports[`Webex Remote Media component snapshot matches snapshot of disabled remo
 <div
   className="wxc-remote-media"
 >
-  <audio
-    autoPlay={true}
+  <RemoteMediaDisplay
+    remoteAudio={Object {}}
+    remoteShare={null}
+    remoteVideo={null}
   />
 </div>
 `;
@@ -25,12 +28,10 @@ exports[`Webex Remote Media component snapshot matches snapshot of enabled remot
 <div
   className="wxc-remote-media"
 >
-  <video
-    autoPlay={true}
-    playsInline={true}
-  />
-  <audio
-    autoPlay={true}
+  <RemoteMediaDisplay
+    remoteAudio={Object {}}
+    remoteShare={null}
+    remoteVideo={Object {}}
   />
 </div>
 `;
@@ -39,12 +40,10 @@ exports[`Webex Remote Media component snapshot matches snapshot of enabled remot
 <div
   className="wxc-remote-media my-custom-class"
 >
-  <video
-    autoPlay={true}
-    playsInline={true}
-  />
-  <audio
-    autoPlay={true}
+  <RemoteMediaDisplay
+    remoteAudio={Object {}}
+    remoteShare={null}
+    remoteVideo={Object {}}
   />
 </div>
 `;


### PR DESCRIPTION
When joining a meeting with no members, the "waiting" screen is displayed. Once another member joins, the stream reference it attempts to map to the video element is no longer valid. Moving the `useStream` hook into a sub component that only will call it when needed fixes the issue.

Reference: https://github.com/facebook/react/issues/11163#issuecomment-628379291