### PR TITLE
ci: specify git config as local

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ jobs:
             rm -rf docs/storybook
             npm run storybook:build
 
-            git config user.name $GIT_AUTHOR_NAME
-            git config user.email $GIT_AUTHOR_EMAIL
+            git config --local user.name $GIT_AUTHOR_NAME
+            git config --local user.email $GIT_AUTHOR_EMAIL
 
             git add docs/storybook
             git commit -m "docs: build Storybook [skip ci]"


### PR DESCRIPTION
Git didn't like it, even though CircleCI recommended it ¯\\\_(ツ)\_/¯.
I blame [CircleCI poor instructions](https://support.circleci.com/hc/en-us/articles/360018860473-How-to-push-a-commit-back-to-the-same-repository-as-part-of-the-CircleCI-job) 😁