### PR TITLE
Handle state when user leaves a meeting

### DIFF
--- a/src/adapters/MeetingsJSONAdapter.js
+++ b/src/adapters/MeetingsJSONAdapter.js
@@ -159,7 +159,19 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
   getMeeting(ID) {
     const end$ = new Subject();
     const getMeeting$ = Observable.create((observer) => {
-      if (this.datasource[ID]) {
+      // A null ID signifies that the meeting is over, in the past or invalid
+      if (ID === null) {
+        observer.next({
+          ID: null,
+          title: null,
+          localAudio: null,
+          localVideo: null,
+          localShare: null,
+          remoteAudio: null,
+          remoteVideo: null,
+          remoteShare: null,
+        });
+      } else if (this.datasource[ID]) {
         observer.next(this.datasource[ID]);
       } else {
         observer.error(new Error(`Could not find meeting with ID "${ID}"`));

--- a/src/adapters/MeetingsJSONAdapter.js
+++ b/src/adapters/MeetingsJSONAdapter.js
@@ -194,6 +194,7 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
     const videoEvents$ = fromEvent(document, MUTE_VIDEO_CONTROL);
     const joinEvents$ = fromEvent(document, JOIN_CONTROL);
     const leaveEvents$ = fromEvent(document, LEAVE_CONTROL).pipe(
+      filter((event) => event.detail.ID === ID),
       tap(() => end$.next(`Meeting "${ID}" has completed.`)),
     );
 

--- a/src/adapters/MeetingsJSONAdapter.test.js
+++ b/src/adapters/MeetingsJSONAdapter.test.js
@@ -65,6 +65,22 @@ describe('Meetings JSON Adapter', () => {
       });
     });
 
+    test('emits an empty Meeting object when ID is null', (done) => {
+      meetingsJSONAdapter.getMeeting(null).subscribe((meeting) => {
+        expect(meeting).toMatchObject({
+          ID: null,
+          title: null,
+          localAudio: null,
+          localVideo: null,
+          localShare: null,
+          remoteAudio: null,
+          remoteVideo: null,
+          remoteShare: null,
+        });
+        done();
+      });
+    });
+
     test('emits Meeting object with null local audio on mute audio event', (done) => {
       meetingsJSONAdapter
         .getMeeting(meetingID)

--- a/src/components/WebexMeeting/WebexMeeting.jsx
+++ b/src/components/WebexMeeting/WebexMeeting.jsx
@@ -31,20 +31,30 @@ export default function WebexMeeting({meetingDestination, controls}) {
     (key) => <WebexMeetingControl key={key} type={key} />,
   );
 
+  let meetingDisplay;
+
+  // Undefined meeting ID means that a meeting has never been set
+  if (ID === undefined) {
+    meetingDisplay = <Spinner />;
+  // A null meeting ID means that a meeting is no longer valid (e.g. user left or kicked out)
+  } else if (ID === null) {
+    meetingDisplay = "You've successfully left the meeting";
+  } else {
+    meetingDisplay = (
+      <>
+        {isActive
+          ? <WebexInMeeting meetingID={ID} />
+          : <WebexInterstitialMeeting meetingID={ID} />}
+        <WebexMeetingControls className="meeting-controls-container" meetingID={ID}>
+          {meetingControls}
+        </WebexMeetingControls>
+      </>
+    );
+  }
+
   return (
     <div className={classNames(mainClasses)}>
-      {ID ? (
-        <>
-          {isActive
-            ? <WebexInMeeting meetingID={ID} />
-            : <WebexInterstitialMeeting meetingID={ID} />}
-          <WebexMeetingControls className="meeting-controls-container" meetingID={ID}>
-            {meetingControls}
-          </WebexMeetingControls>
-        </>
-      ) : (
-        <Spinner />
-      )}
+      {meetingDisplay}
     </div>
   );
 }

--- a/src/components/WebexMeeting/WebexMeeting.stories.js
+++ b/src/components/WebexMeeting/WebexMeeting.stories.js
@@ -19,7 +19,7 @@ Interstitial.args = {
 
 export const Loading = Template.bind({});
 Loading.args = {
-  meetingDestination: 'meeting8',
+  meetingDestination: 'meeting9',
 };
 
 export const WaitingForOthers = Template.bind({});

--- a/src/components/WebexMeeting/WebexMeeting.stories.js
+++ b/src/components/WebexMeeting/WebexMeeting.stories.js
@@ -32,8 +32,13 @@ InMeeting.args = {
   meetingDestination: 'meeting1',
 };
 
+export const LeftMeeting = Template.bind({});
+LeftMeeting.args = {
+  meetingDestination: 'meeting8',
+};
+
 export const CustomControls = Template.bind({});
 CustomControls.args = {
-  meetingDestination: 'meeting6',
+  meetingDestination: 'meeting3',
   controls: (isActive) => (isActive ? ['leave-meeting'] : ['join-meeting']),
 };

--- a/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
+++ b/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
@@ -10,21 +10,20 @@ exports[`Storyshots Meetings/Webex Meeting Custom Controls 1`] = `
   }
 >
   <div
-    className="wxc-meeting wxc-meeting-active"
+    className="wxc-meeting"
   >
     <div
-      className="wxc-in-meeting"
+      className="wxc-interstitial-meeting"
     >
       <div
-        className="wxc-remote-media remote-media-in-meeting"
+        className="wxc-meeting-info interstitial-meeting-info"
       >
-        <video
-          autoPlay={true}
-          playsInline={true}
-        />
+        <h2>
+          Quarterly Financial Report
+        </h2>
       </div>
       <div
-        className="wxc-local-media local-media-in-meeting"
+        className="wxc-local-media"
       >
         <video
           autoPlay={true}
@@ -36,11 +35,12 @@ exports[`Storyshots Meetings/Webex Meeting Custom Controls 1`] = `
       className="wxc-meeting-controls meeting-controls-container"
     >
       <button
-        alt="Leave"
-        aria-label="Leave"
+        alt="Join meeting"
+        aria-label="Join meeting"
         aria-pressed={null}
-        className="md-button md-button--circle md-button--56 md-button--red"
+        className="md-button md-button--52 md-button--green"
         data-md-event-key="md-button-0"
+        data-md-keyboard-key="join-meeting"
         disabled={false}
         id="md-button-0"
         onClick={[Function]}
@@ -61,15 +61,7 @@ exports[`Storyshots Meetings/Webex Meeting Custom Controls 1`] = `
             }
           }
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-cancel_28"
-            style={
-              Object {
-                "fontSize": 28,
-              }
-            }
-          />
+          Join meeting
         </span>
       </button>
     </div>
@@ -411,6 +403,23 @@ exports[`Storyshots Meetings/Webex Meeting Interstitial 1`] = `
         </span>
       </button>
     </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Meetings/Webex Meeting Left Meeting 1`] = `
+<div
+  style={
+    Object {
+      "height": "500px",
+      "width": "650px",
+    }
+  }
+>
+  <div
+    className="wxc-meeting"
+  >
+    You've successfully left the meeting
   </div>
 </div>
 `;

--- a/src/components/WebexMeetingInfo/WebexMeetingInfo.stories.js
+++ b/src/components/WebexMeetingInfo/WebexMeetingInfo.stories.js
@@ -10,7 +10,7 @@ const Template = (args) => <WebexMeetingInfo {...args} />;
 
 export const Loading = Template.bind({});
 Loading.args = {
-  meetingID: 'meeting8',
+  meetingID: 'meeting9',
 };
 
 export const Error = Template.bind({});

--- a/src/components/WebexRemoteMedia/WebexRemoteMedia.stories.js
+++ b/src/components/WebexRemoteMedia/WebexRemoteMedia.stories.js
@@ -37,5 +37,5 @@ AllRemoteMedia.args = {
 
 export const Error = Template.bind({});
 Error.args = {
-  meetingID: 'meeting8',
+  meetingID: 'meeting9',
 };

--- a/src/components/hooks/useMeetingDestination.js
+++ b/src/components/hooks/useMeetingDestination.js
@@ -21,16 +21,18 @@ import {AdapterContext} from './contexts';
  */
 export default function useMeetingDestination(meetingDestination) {
   const emptyMeeting = {
-    ID: null,
     title: null,
     localAudio: null,
     localVideo: null,
     remoteAudio: null,
     remoteVideo: null,
   };
+  const endedMeeting = {
+    ...emptyMeeting,
+    ID: null,
+  };
 
   const [meeting, setMeeting] = useState(emptyMeeting);
-  // const [createNewMeeting, setCreateNewMeeting] = useState(false);
   const {meetingsAdapter} = useContext(AdapterContext);
 
   useEffect(() => {
@@ -46,8 +48,7 @@ export default function useMeetingDestination(meetingDestination) {
       console.log(error);
     };
     const onComplete = () => {
-      // setCreateNewMeeting(!createNewMeeting);
-      setMeeting(emptyMeeting);
+      setMeeting(endedMeeting);
     };
 
     const subscription = meetingsAdapter

--- a/src/data/meetings.js
+++ b/src/data/meetings.js
@@ -70,6 +70,16 @@ export default {
     remoteShare: null,
   },
   meeting8: {
+    ID: null,
+    title: null,
+    localAudio: null,
+    localVideo: null,
+    localShare: null,
+    remoteAudio: null,
+    remoteVideo: null,
+    remoteShare: null,
+  },
+  meeting9: {
     error: true,
   },
 };


### PR DESCRIPTION
Changing the flow when a user leaves a meeting. Instead of attempting to reset the meeting, we simply let the user know that they have left the meeting.
If they wish to rejoin the meeting, they can restart the meeting flow. This aligns with changes in the SDK where once a user leaves a meeting, a new meetingID is given, and simplifies the flow.