### PR TITLE
Remote Media Styles Fixes

### DIFF
--- a/src/components/WebexInMeeting/__snapshots__/WebexInMeeting.stories.storyshot
+++ b/src/components/WebexInMeeting/__snapshots__/WebexInMeeting.stories.storyshot
@@ -6,14 +6,18 @@ Array [
     className="wxc-in-meeting"
   >
     <div
-      className="wxc-remote-media remote-media-in-meeting split-screen"
+      className="wxc-remote-media remote-media-in-meeting remote-video-n-share"
     >
       <video
         autoPlay={true}
+        className="wxc-remote-video"
+        muted={true}
         playsInline={true}
       />
       <video
         autoPlay={true}
+        className="wxc-remote-share"
+        muted={true}
         playsInline={true}
       />
       <audio
@@ -48,14 +52,18 @@ Array [
     className="wxc-in-meeting"
   >
     <div
-      className="wxc-remote-media remote-media-in-meeting split-screen"
+      className="wxc-remote-media remote-media-in-meeting remote-video-n-share"
     >
       <video
         autoPlay={true}
+        className="wxc-remote-video"
+        muted={true}
         playsInline={true}
       />
       <video
         autoPlay={true}
+        className="wxc-remote-share"
+        muted={true}
         playsInline={true}
       />
       <audio

--- a/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
+++ b/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
@@ -81,14 +81,18 @@ Array [
       className="wxc-in-meeting"
     >
       <div
-        className="wxc-remote-media remote-media-in-meeting split-screen"
+        className="wxc-remote-media remote-media-in-meeting remote-video-n-share"
       >
         <video
           autoPlay={true}
+          className="wxc-remote-video"
+          muted={true}
           playsInline={true}
         />
         <video
           autoPlay={true}
+          className="wxc-remote-share"
+          muted={true}
           playsInline={true}
         />
         <audio

--- a/src/components/WebexRemoteMedia/WebexRemoteMedia.jsx
+++ b/src/components/WebexRemoteMedia/WebexRemoteMedia.jsx
@@ -5,7 +5,13 @@ import classNames from 'classnames';
 import {Badge, Spinner, AlertBanner} from '@momentum-ui/react';
 
 import {WEBEX_COMPONENTS_CLASS_PREFIX} from '../../constants';
-import {useMeeting, useMemberships, useStream} from '../hooks';
+import {TABLET, DESKTOP, DESKTOP_LARGE} from '../breakpoints';
+import {
+  useElementDimensions,
+  useMeeting,
+  useMemberships,
+  useStream,
+} from '../hooks';
 
 /**
  * Webex Remote Media component displays the meeting's remote video
@@ -28,14 +34,21 @@ export default function WebexRemoteMedia({className, meetingID}) {
   const audioRef = useStream(remoteAudio);
   const videoRef = useStream(remoteVideo);
   const shareRef = useStream(remoteShare);
+  const [remoteMediaRef, {width}] = useElementDimensions();
+
   const hasOtherMembers = members.length > 1;
   const hasMedia = !!(remoteAudio || remoteVideo || remoteShare);
-  const hasTwoMedia = remoteVideo && remoteShare;
+
+  const classBaseName = `${WEBEX_COMPONENTS_CLASS_PREFIX}-remote-media`;
   const mainClasses = {
-    [`${WEBEX_COMPONENTS_CLASS_PREFIX}-remote-media`]: true,
+    [`${classBaseName}`]: true,
+    [`${classBaseName}-tablet`]: width >= TABLET && width < DESKTOP,
+    [`${classBaseName}-desktop`]: width >= DESKTOP && width < DESKTOP_LARGE,
+    [`${classBaseName}-desktop-xl`]: width >= DESKTOP_LARGE,
     [className]: !!className,
-    'split-screen': hasTwoMedia,
+    'remote-video-n-share': remoteVideo && remoteShare,
   };
+
   let remoteDisplay;
 
   if (error) {
@@ -47,11 +60,11 @@ export default function WebexRemoteMedia({className, meetingID}) {
   } else if (hasMedia && hasOtherMembers) {
     remoteDisplay = (
       <>
-        {remoteVideo ? <video ref={videoRef} playsInline autoPlay /> : null}
-
-        {remoteShare ? <video ref={shareRef} playsInline autoPlay /> : null}
-
-        {remoteAudio ? <audio ref={audioRef} autoPlay /> : null}
+        {remoteVideo
+          && <video className={`${WEBEX_COMPONENTS_CLASS_PREFIX}-remote-video`} ref={videoRef} muted playsInline autoPlay />}
+        {remoteShare
+          && <video className={`${WEBEX_COMPONENTS_CLASS_PREFIX}-remote-share`} ref={shareRef} muted playsInline autoPlay />}
+        {remoteAudio && <audio ref={audioRef} autoPlay />}
       </>
     );
   } else if (hasMedia && !hasOtherMembers) {
@@ -70,7 +83,7 @@ export default function WebexRemoteMedia({className, meetingID}) {
   }
 
   return (
-    <div className={classNames(mainClasses)}>
+    <div ref={remoteMediaRef} className={classNames(mainClasses)}>
       {remoteDisplay}
     </div>
   );

--- a/src/components/WebexRemoteMedia/WebexRemoteMedia.scss
+++ b/src/components/WebexRemoteMedia/WebexRemoteMedia.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
   height: 100%;
   width: 100%;
   position: relative;
@@ -10,6 +11,7 @@
   .md-alert-banner {
     position: absolute;
     top: 0;
+
     width: 100%;
   }
 
@@ -27,10 +29,56 @@
     width: 100%;
   }
 
-  &.split-screen{
-    video {
-      width: 50%;
-      height: auto;
+  &.remote-video-n-share {
+    .#{$WEBEX_COMPONENTS_CLASS_PREFIX}-remote-video {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+
+      height: 5rem;
+      width: 9rem;
+
+      box-shadow: $shadow-offset $shadow-offset $shadow-blur $shadow-spread $shadow-color;
+      border-radius: 0.25rem;
+      z-index: 1;
+    }
+
+    .#{$WEBEX_COMPONENTS_CLASS_PREFIX}-remote-share {
+      flex-grow: 1;
+    }
+  }
+
+
+  &-tablet {
+      &.remote-video-n-share {
+      .#{$WEBEX_COMPONENTS_CLASS_PREFIX}-remote-video {
+        top: 1rem;
+        right: 1rem;
+
+        height: 7.5rem;
+        width: 13.5rem;
+      }
+    }
+  }
+
+  &-desktop {
+    &.remote-video-n-share {
+     .#{$WEBEX_COMPONENTS_CLASS_PREFIX}-remote-video {
+        height: 7.5rem;
+        width: 13.5rem;
+      }
+    }
+  }
+
+  &-desktop-xl {
+    &.remote-video-n-share {
+     .#{$WEBEX_COMPONENTS_CLASS_PREFIX}-remote-video {
+        top: 2rem;
+        right: 2rem;
+
+        height: 9.5rem;
+        width: 17rem;
+      }
     }
   }
 }

--- a/src/components/WebexRemoteMedia/WebexRemoteMedia.scss
+++ b/src/components/WebexRemoteMedia/WebexRemoteMedia.scss
@@ -1,11 +1,14 @@
 .#{$WEBEX_COMPONENTS_CLASS_PREFIX}-remote-media {
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
 
   height: 100%;
   width: 100%;
-  position: relative;
+  min-height: $WEBEX_MEETING_MIN_HEIGHT;
+  min-width: $WEBEX_MEETING_MIN_WIDTH;
+
   background: white;
 
   .md-alert-banner {

--- a/src/components/WebexRemoteMedia/__snapshots__/WebexRemoteMedia.stories.storyshot
+++ b/src/components/WebexRemoteMedia/__snapshots__/WebexRemoteMedia.stories.storyshot
@@ -3,14 +3,18 @@
 exports[`Storyshots Meetings/Webex Remote Media All Remote Media 1`] = `
 Array [
   <div
-    className="wxc-remote-media split-screen"
+    className="wxc-remote-media remote-video-n-share"
   >
     <video
       autoPlay={true}
+      className="wxc-remote-video"
+      muted={true}
       playsInline={true}
     />
     <video
       autoPlay={true}
+      className="wxc-remote-share"
+      muted={true}
       playsInline={true}
     />
     <audio
@@ -116,6 +120,8 @@ Array [
   >
     <video
       autoPlay={true}
+      className="wxc-remote-video"
+      muted={true}
       playsInline={true}
     />
   </div>,


### PR DESCRIPTION
This changes the display style when there is remote video + screen share. Currently, the script is split 50%-50% which makes it hard to see the screen share. This updates the style so that video is shrunk and send to the top-right corner while screen share takes over the the full parent's (element) size.