### PR TITLE
Checkout repository before running storybook step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - $RW_FINGERPRINT
-      - attach_workspace:
-          at: .
+      - checkout
       - run:
           name: Update Storybook
           command: |


### PR DESCRIPTION
Checking before running Storybook does two things:
- Bring the CI branch with changes from release
- Adds github.com to ~/.ssh/known_host so we can push back changes to Github