### PR TITLE
build(bump): allowing newest momentum ui for node bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "peerDependencies": {
     "@babel/runtime": "^7.11.2",
-    "@momentum-ui/react": "23.17.4",
+    "@momentum-ui/react": "^23.17.4",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Missing the caret on the momentum-ui/react dependency, which is breaking a bump in Cisco Online Account Management Portal. Thank you!