### PR TITLE
ci: integrate remote changes before building Storybook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           command: |
             # Check if there's anything to commit
             if [ -n "$(git status --porcelain)" ]; then
+              git pull
               git add docs/storybook
               git commit -m "docs: build Storybook [skip ci]"
               git push origin master


### PR DESCRIPTION
I checked CircleCI's `checkout` command and it only fetches the remote branch but it doesn't integrate the changes on the workspace. Updating Storybook step to pull before committing.

Found after [this CI job failure](https://app.circleci.com/pipelines/github/webex/components/993/workflows/7fd74037-40e6-4aa1-b181-4ff488260d4c/jobs/2093)