### PR TITLE
feat(WebexMember): display exernal user's organization

### DIFF
--- a/src/components/WebexMember/WebexMember.jsx
+++ b/src/components/WebexMember/WebexMember.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {DestinationType} from '@webex/component-adapter-interfaces';
 import {Icon} from '@momentum-ui/react';
 
-import {usePerson, useMembers, useMe} from '../hooks';
+import {usePerson, useMembers, useMe, useOrganization} from '../hooks';
 import WebexAvatar from '../WebexAvatar/WebexAvatar';
 import {WEBEX_COMPONENTS_CLASS_PREFIX} from '../../constants';
 
@@ -23,13 +23,15 @@ export default function WebexMember({
   personID,
   displayStatus,
 }) {
-  const {firstName, lastName} = usePerson(personID);
+  const {firstName, lastName, orgID} = usePerson(personID);
   const me = useMe();
   const members = useMembers(destinationID, destinationType);
   const member = members
     .find((itemMember) => itemMember.ID === personID);
+  const organization = useOrganization(orgID);
 
   const isMuted = member && member.muted;
+  const isExternal = me.orgID !== orgID;
   const isSharing = member && member.sharing;
   const showMe = me.ID === personID && destinationType === DestinationType.MEETING;
   const isHost = member && member.host;
@@ -46,6 +48,7 @@ export default function WebexMember({
       <div className="details">
         <div className="name">{`${firstName} ${lastName}`}</div>
         {roles.length > 0 && <div className="roles">{roles.join(', ')}</div>}
+        {isExternal && <div className="organization">{organization.name}</div>}
       </div>
       {isSharing && <Icon name="icon-content-share_16" className="sharing" />}
       {isMuted && <Icon name="icon-microphone-muted_16" className="muted" />}

--- a/src/components/WebexMember/WebexMember.scss
+++ b/src/components/WebexMember/WebexMember.scss
@@ -21,6 +21,11 @@
     color: $md-gray-70;
   }
 
+  .organization {
+    font-size: 0.875rem;
+    color: $md-yellow-40;
+  }
+
   .sharing {
     margin-right: 2.5rem;
   }

--- a/src/components/WebexMember/WebexMember.stories.js
+++ b/src/components/WebexMember/WebexMember.stories.js
@@ -27,6 +27,13 @@ Muted.args = {
   personID: 'user2',
 };
 
+export const ExternalOrganization = Template.bind({});
+ExternalOrganization.args = {
+  destinationType: 'room',
+  destinationID: 'room2',
+  personID: 'user5',
+};
+
 export const Host = Template.bind({});
 Host.args = {
   destinationType: 'meeting',

--- a/src/components/WebexMember/__snapshots__/WebexMember.stories.storyshot
+++ b/src/components/WebexMember/__snapshots__/WebexMember.stories.storyshot
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Platform/Webex Member External Organization 1`] = `
+Array [
+  <div
+    style={
+      Object {
+        "width": "20rem",
+      }
+    }
+  >
+    <div
+      className="wxc-member"
+    >
+      <div
+        className="md-avatar md-avatar--medium"
+        title="Brandon Seeger"
+      >
+        <span
+          className="md-avatar__letter"
+          style={
+            Object {
+              "backgroundColor": "",
+              "color": "",
+            }
+          }
+        >
+          BS
+        </span>
+        <img
+          alt="Brandon Seeger"
+          className="md-avatar__img md-avatar__img--hidden"
+          draggable={false}
+          onError={[Function]}
+          onLoad={[Function]}
+          src="./images/brandon.png"
+        />
+      </div>
+      <div
+        className="details"
+      >
+        <div
+          className="name"
+        >
+          Brandon Seeger
+        </div>
+        <div
+          className="organization"
+        >
+          Gmail.com
+        </div>
+      </div>
+    </div>
+  </div>,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-video"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-meeting.mp4"
+    width="0"
+  />,
+]
+`;
+
 exports[`Storyshots Platform/Webex Member Host 1`] = `
 Array [
   <div

--- a/src/components/WebexMemberRoster/__snapshots__/WebexMemberRoster.stories.storyshot
+++ b/src/components/WebexMemberRoster/__snapshots__/WebexMemberRoster.stories.storyshot
@@ -101,6 +101,11 @@ Array [
           >
             Brandon Seeger
           </div>
+          <div
+            className="organization"
+          >
+            Gmail.com
+          </div>
         </div>
       </div>
       <div


### PR DESCRIPTION
Updated WebexMember to display the external user's organization name in WebexMemberRoster if the member is not from the same organization as the current user.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-220418