### PR TITLE
refactor(WebexJsonAdaptor): separate localShare from remoteShare

### DIFF
--- a/src/adapters/MeetingsJSONAdapter.js
+++ b/src/adapters/MeetingsJSONAdapter.js
@@ -196,15 +196,7 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
     });
 
     // Send updates on the meeting when an action is triggered
-    const shareEvents$ = fromEvent(document, SHARE_CONTROL).pipe(
-      tap(() => {
-        const meeting = this.datasource[ID];
-
-        // Use local screen share to fake a remote user's screen sharing
-        meeting.remoteShare = meeting.localShare;
-      }),
-    );
-
+    const shareEvents$ = fromEvent(document, SHARE_CONTROL);
     const audioEvents$ = fromEvent(document, MUTE_AUDIO_CONTROL);
     const videoEvents$ = fromEvent(document, MUTE_VIDEO_CONTROL);
     const joinEvents$ = fromEvent(document, JOIN_CONTROL);
@@ -542,12 +534,12 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
       meeting.localShare = null;
     } else {
       meeting.localShare = await this.getDisplayStream();
+      meeting.remoteShare = null;
 
       if (meeting.localShare) {
         // Handle browser's built-in stop Button
         meeting.localShare.getVideoTracks()[0].onended = () => {
           meeting.localShare = null;
-          meeting.remoteShare = null;
           document.dispatchEvent(new CustomEvent(SHARE_CONTROL, {detail: meeting}));
         };
       }

--- a/src/components/WebexInMeeting/__snapshots__/WebexInMeeting.stories.storyshot
+++ b/src/components/WebexInMeeting/__snapshots__/WebexInMeeting.stories.storyshot
@@ -164,20 +164,14 @@ Array [
 exports[`Storyshots Meetings/Webex In-Meeting Sharing 1`] = `
 Array [
   <div
-    className="wxc-in-meeting remote-sharing"
+    className="wxc-in-meeting"
   >
     <div
-      className="wxc-remote-media remote-media-in-meeting remote-video-n-share"
+      className="wxc-remote-media remote-media-in-meeting"
     >
       <video
         autoPlay={true}
         className="wxc-remote-video"
-        muted={true}
-        playsInline={true}
-      />
-      <video
-        autoPlay={true}
-        className="wxc-remote-share"
         muted={true}
         playsInline={true}
       />

--- a/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
+++ b/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
@@ -78,20 +78,14 @@ Array [
     className="wxc-meeting wxc-meeting-active"
   >
     <div
-      className="wxc-in-meeting remote-sharing"
+      className="wxc-in-meeting"
     >
       <div
-        className="wxc-remote-media remote-media-in-meeting remote-video-n-share"
+        className="wxc-remote-media remote-media-in-meeting"
       >
         <video
           autoPlay={true}
           className="wxc-remote-video"
-          muted={true}
-          playsInline={true}
-        />
-        <video
-          autoPlay={true}
-          className="wxc-remote-share"
           muted={true}
           playsInline={true}
         />

--- a/src/data/meetings.js
+++ b/src/data/meetings.js
@@ -7,7 +7,7 @@ export default {
     localShare: new MediaStream(),
     remoteAudio: new MediaStream(),
     remoteVideo: new MediaStream(),
-    remoteShare: new MediaStream(),
+    remoteShare: null,
     showRoster: false,
   },
   meeting2: {


### PR DESCRIPTION
Separate remote share logic from local share. Remote share should take its value only from the meeting object

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-227221