### PR TITLE
fix(useMeetingDestination): work even if an adapter is not yet present on the context

### DIFF
--- a/src/components/hooks/useMeetingDestination.js
+++ b/src/components/hooks/useMeetingDestination.js
@@ -30,12 +30,13 @@ const emptyMeeting = {
  */
 export default function useMeetingDestination(meetingDestination) {
   const [meeting, setMeeting] = useState(emptyMeeting);
-  const {meetingsAdapter} = useContext(AdapterContext);
+  const adapter = useContext(AdapterContext);
+  const meetingsAdapter = adapter && adapter.meetingsAdapter;
 
   useEffect(() => {
     let cleanup;
 
-    if (!meetingDestination) {
+    if (!meetingDestination || !meetingsAdapter) {
       setMeeting({...emptyMeeting});
       cleanup = undefined;
     } else {


### PR DESCRIPTION
Make the useMeetingDestination hook work even if an adapter is not yet present on the context
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-233400