### PR TITLE
feat(WebexMeeting): remove WebexMeetingControlBar from WebexMeeting component

### DIFF
--- a/src/components/WebexMeeting/README.md
+++ b/src/components/WebexMeeting/README.md
@@ -1,6 +1,7 @@
 # Webex Meeting Component
 
-Webex Meeting component displays the complete, default Webex meeting experience.
+Webex Meeting component displays the [Webex In Meeting](../WebexInMeeting) component or the
+[Webex Interstitial Meeting](../WebexInterstitialMeeting) component depending on the state of the meeting.
 
 <p align="center">
   <img src="./WebexMeeting.gif" alt="Default Webex Meeting" />
@@ -24,18 +25,13 @@ or run the following **NPM** command:
     const jsonAdapter = new WebexJSONAdapter(jsonData);
     ```
 
-2. Create a component instance by passing the meeting ID as a string and an optional function that returns an array
-of control names for the meeting. The default control names are set to `['mute-audio', 'mute-video', 'join-meeting]`
-if the meeting is inactive and `['mute-audio', 'mute-video', 'leave-meeting']` otherwise.
-Ensure that the control names match with the adapter implementation of the controls. You then need to enclose it
+2. Create a component instance by passing the meeting ID as a string. You then need to enclose it
 within [a data provider](../WebexDataProvider/WebexDataProvider.js) that takes
 the [component data adapter](../../adapters/WebexJSONAdapter.js) that we created previously
 
     ```js
-    const controls = (isActive) => isActive ? ['join-meeting'] : ['leave-meeting'];
-
     <WebexDataProvider adapter={jsonAdapter}>
-      <WebexMeeting meetingID="meetingID" controls?={controls}/>
+      <WebexMeeting meetingID="meetingID"/>
     </WebexDataProvider>
     ```
 

--- a/src/components/WebexMeeting/WebexMeeting.jsx
+++ b/src/components/WebexMeeting/WebexMeeting.jsx
@@ -6,7 +6,6 @@ import {MeetingState} from '@webex/component-adapter-interfaces';
 
 import WebexInMeeting from '../WebexInMeeting/WebexInMeeting';
 import WebexInterstitialMeeting from '../WebexInterstitialMeeting/WebexInterstitialMeeting';
-import WebexMeetingControlBar from '../WebexMeetingControlBar/WebexMeetingControlBar';
 import {WEBEX_COMPONENTS_CLASS_PREFIX} from '../../constants';
 import {useMeeting} from '../hooks';
 
@@ -25,7 +24,6 @@ export default function WebexMeeting({meetingID}) {
   const classBaseName = `${WEBEX_COMPONENTS_CLASS_PREFIX}-meeting`;
   const mainClasses = {
     [classBaseName]: true,
-    [`${classBaseName}-active`]: ID && isActive,
   };
 
   let meetingDisplay;
@@ -41,7 +39,6 @@ export default function WebexMeeting({meetingID}) {
         {isActive
           ? <WebexInMeeting meetingID={ID} />
           : <WebexInterstitialMeeting meetingID={ID} />}
-        <WebexMeetingControlBar className="meeting-controls-container" meetingID={ID} />
       </>
     );
   }

--- a/src/components/WebexMeeting/WebexMeeting.scss
+++ b/src/components/WebexMeeting/WebexMeeting.scss
@@ -10,46 +10,4 @@
   min-height: $WEBEX_MEETING_MIN_HEIGHT;
   min-width: $WEBEX_MEETING_MIN_WIDTH;
 
-  .meeting-controls-container {
-    position: absolute;
-    bottom: 2rem;
-
-    z-index: 100; // Arbitrary large number
-  }
-
-  &-active  {
-    .meeting-controls {
-      .md-button {
-        display: none;
-      }
-
-      // Display active controls
-      .md-button--red {
-        display: block;
-
-        background-color: rgba($color: #A12C23, $alpha: 0.4);
-        border: solid 1px #D93829;
-        color: #D93829;
-
-        // Assumes "leave" is last child
-        &:last-child {
-          display: none;
-        }
-      }
-    }
-  }
-
-  &-active:hover, &-active:active {
-    .meeting-controls {
-      .md-button {
-        display: block;
-      }
-
-      .md-button--red {
-        background: #FF5C4A;
-        border-color: transparent;
-        color: #FFFFFF;
-      }
-    }
-  }
 }

--- a/src/components/WebexMeeting/WebexMeeting.stories.js
+++ b/src/components/WebexMeeting/WebexMeeting.stories.js
@@ -1,9 +1,32 @@
 import React from 'react';
 import WebexMeeting from './WebexMeeting';
+import WebexMeetingControlBar from '../WebexMeetingControlBar/WebexMeetingControlBar';
+
+const containerStyle = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+  'min-height': '25rem',
+};
+
+const controlBarStyle = {
+  position: 'absolute',
+  bottom: '1rem',
+  left: 0,
+  right: 0,
+};
 
 export default {
   title: 'Meetings/Webex Meeting',
   component: WebexMeeting,
+  decorators: [(Story, context) => (
+    <div style={containerStyle}>
+      <Story />
+      <div style={controlBarStyle}>
+        <WebexMeetingControlBar meetingID={context.args.meetingID} />
+      </div>
+    </div>
+  )],
 };
 
 const Template = (args) => <WebexMeeting {...args} />;
@@ -31,10 +54,4 @@ InMeeting.args = {
 export const LeftMeeting = Template.bind({});
 LeftMeeting.args = {
   meetingID: 'meeting8',
-};
-
-export const CustomControls = Template.bind({});
-CustomControls.args = {
-  meetingID: 'meeting3',
-  controls: (isActive) => (isActive ? ['leave-meeting'] : ['join-meeting']),
 };

--- a/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
+++ b/src/components/WebexMeeting/__snapshots__/WebexMeeting.stories.storyshot
@@ -1,421 +1,250 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Meetings/Webex Meeting Custom Controls 1`] = `
-Array [
-  <div
-    className="wxc-meeting"
-  >
-    <div
-      className="wxc-interstitial-meeting"
-    >
-      <div
-        className="wxc-meeting-info interstitial-meeting-info"
-      >
-        <h2>
-          Quarterly Financial Report
-        </h2>
-      </div>
-      <div
-        className="wxc-local-media interstitial-media"
-      >
-        <video
-          autoPlay={true}
-          playsInline={true}
-        />
-      </div>
-    </div>
-    <div
-      className="wxc-meeting-control-bar meeting-controls-container"
-    >
-      <button
-        alt="Show settings panel"
-        aria-label="Show settings panel"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
-          style={
-            Object {
-              "opacity": "1",
-            }
-          }
-        >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-settings_32"
-            style={
-              Object {
-                "fontSize": 28,
-              }
-            }
-          />
-        </span>
-      </button>
-      <button
-        alt="Mute"
-        aria-label="Mute"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
-          style={
-            Object {
-              "opacity": "1",
-            }
-          }
-        >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-microphone-muted_28"
-            style={
-              Object {
-                "fontSize": 28,
-              }
-            }
-          />
-        </span>
-      </button>
-      <button
-        alt="Stop video"
-        aria-label="Stop video"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
-          style={
-            Object {
-              "opacity": "1",
-            }
-          }
-        >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-camera-muted_28"
-            style={
-              Object {
-                "fontSize": 28,
-              }
-            }
-          />
-        </span>
-      </button>
-      <button
-        alt="Join meeting"
-        aria-label="Join meeting"
-        aria-pressed={null}
-        className="md-button md-button--52 md-button--green"
-        data-md-event-key="md-button-0"
-        data-md-keyboard-key="join-meeting"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
-          style={
-            Object {
-              "opacity": "1",
-            }
-          }
-        >
-          Join meeting
-        </span>
-      </button>
-    </div>
-  </div>,
-  <video
-    autoPlay={true}
-    height="0"
-    id="remote-video"
-    loop={true}
-    muted={true}
-    playsInline={true}
-    src="./video/ongoing-meeting.mp4"
-    width="0"
-  />,
-  <video
-    autoPlay={true}
-    height="0"
-    id="remote-share"
-    loop={true}
-    muted={true}
-    playsInline={true}
-    src="./video/ongoing-share.mp4"
-    width="0"
-  />,
-]
-`;
-
 exports[`Storyshots Meetings/Webex Meeting In Meeting 1`] = `
 Array [
   <div
-    className="wxc-meeting wxc-meeting-active"
+    style={
+      Object {
+        "height": "100%",
+        "min-height": "25rem",
+        "position": "relative",
+        "width": "100%",
+      }
+    }
   >
     <div
-      className="wxc-in-meeting"
+      className="wxc-meeting"
     >
       <div
-        className="wxc-remote-media remote-media-in-meeting"
+        className="wxc-in-meeting"
       >
-        <video
-          autoPlay={true}
-          className="wxc-remote-video"
-          muted={true}
-          playsInline={true}
-        />
-        <audio
-          autoPlay={true}
-        />
-      </div>
-      <div
-        className="wxc-local-media local-media-in-meeting"
-      >
-        <video
-          autoPlay={true}
-          playsInline={true}
-        />
-      </div>
-      <div
-        className="share-notice"
-      >
-        You're sharing your screen
+        <div
+          className="wxc-remote-media remote-media-in-meeting"
+        >
+          <video
+            autoPlay={true}
+            className="wxc-remote-video"
+            muted={true}
+            playsInline={true}
+          />
+          <audio
+            autoPlay={true}
+          />
+        </div>
+        <div
+          className="wxc-local-media local-media-in-meeting"
+        >
+          <video
+            autoPlay={true}
+            playsInline={true}
+          />
+        </div>
+        <div
+          className="share-notice"
+        >
+          You're sharing your screen
+        </div>
       </div>
     </div>
     <div
-      className="wxc-meeting-control-bar meeting-controls-container"
+      style={
+        Object {
+          "bottom": "1rem",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+        }
+      }
     >
-      <button
-        alt="Show settings panel"
-        aria-label="Show settings panel"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
+      <div
+        className="wxc-meeting-control-bar"
       >
-        <span
-          className="md-button__children"
+        <button
+          alt="Show settings panel"
+          aria-label="Show settings panel"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-settings_32"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Mute"
-        aria-label="Mute"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-settings_32"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Mute"
+          aria-label="Mute"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-microphone-muted_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Stop video"
-        aria-label="Stop video"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-microphone-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Stop video"
+          aria-label="Stop video"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-camera-muted_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Stop Sharing"
-        aria-label="Stop Sharing"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56 md-button--red"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-camera-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Stop Sharing"
+          aria-label="Stop Sharing"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-share-screen-presence-stroke_26"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Leave"
-        aria-label="Leave"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56 md-button--red"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-share-screen-presence-stroke_26"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Leave"
+          aria-label="Leave"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-cancel_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-cancel_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+      </div>
     </div>
   </div>,
   <video
@@ -444,171 +273,193 @@ Array [
 exports[`Storyshots Meetings/Webex Meeting Interstitial 1`] = `
 Array [
   <div
-    className="wxc-meeting"
+    style={
+      Object {
+        "height": "100%",
+        "min-height": "25rem",
+        "position": "relative",
+        "width": "100%",
+      }
+    }
   >
     <div
-      className="wxc-interstitial-meeting"
+      className="wxc-meeting"
     >
       <div
-        className="wxc-meeting-info interstitial-meeting-info"
+        className="wxc-interstitial-meeting"
       >
-        <h2>
-          Quarterly Financial Report
-        </h2>
-      </div>
-      <div
-        className="wxc-local-media interstitial-media"
-      >
-        <video
-          autoPlay={true}
-          playsInline={true}
-        />
+        <div
+          className="wxc-meeting-info interstitial-meeting-info"
+        >
+          <h2>
+            Quarterly Financial Report
+          </h2>
+        </div>
+        <div
+          className="wxc-local-media interstitial-media"
+        >
+          <video
+            autoPlay={true}
+            playsInline={true}
+          />
+        </div>
       </div>
     </div>
     <div
-      className="wxc-meeting-control-bar meeting-controls-container"
+      style={
+        Object {
+          "bottom": "1rem",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+        }
+      }
     >
-      <button
-        alt="Show settings panel"
-        aria-label="Show settings panel"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
+      <div
+        className="wxc-meeting-control-bar"
       >
-        <span
-          className="md-button__children"
+        <button
+          alt="Show settings panel"
+          aria-label="Show settings panel"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-settings_32"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Mute"
-        aria-label="Mute"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-settings_32"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Mute"
+          aria-label="Mute"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-microphone-muted_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Stop video"
-        aria-label="Stop video"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-microphone-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Stop video"
+          aria-label="Stop video"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-camera-muted_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Join meeting"
-        aria-label="Join meeting"
-        aria-pressed={null}
-        className="md-button md-button--52 md-button--green"
-        data-md-event-key="md-button-0"
-        data-md-keyboard-key="join-meeting"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-camera-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Join meeting"
+          aria-label="Join meeting"
+          aria-pressed={null}
+          className="md-button md-button--52 md-button--green"
+          data-md-event-key="md-button-0"
+          data-md-keyboard-key="join-meeting"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          Join meeting
-        </span>
-      </button>
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            Join meeting
+          </span>
+        </button>
+      </div>
     </div>
   </div>,
   <video
@@ -637,9 +488,176 @@ Array [
 exports[`Storyshots Meetings/Webex Meeting Left Meeting 1`] = `
 Array [
   <div
-    className="wxc-meeting"
+    style={
+      Object {
+        "height": "100%",
+        "min-height": "25rem",
+        "position": "relative",
+        "width": "100%",
+      }
+    }
   >
-    You've successfully left the meeting
+    <div
+      className="wxc-meeting"
+    >
+      You've successfully left the meeting
+    </div>
+    <div
+      style={
+        Object {
+          "bottom": "1rem",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+        }
+      }
+    >
+      <div
+        className="wxc-meeting-control-bar"
+      >
+        <button
+          alt="Show settings panel"
+          aria-label="Show settings panel"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-settings_32"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Unmute"
+          aria-label="Unmute"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-microphone-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Start video"
+          aria-label="Start video"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-camera-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Join meeting"
+          aria-label="Join meeting"
+          aria-pressed={null}
+          className="md-button md-button--52 md-button--green"
+          data-md-event-key="md-button-0"
+          data-md-keyboard-key="join-meeting"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            Join meeting
+          </span>
+        </button>
+      </div>
+    </div>
   </div>,
   <video
     autoPlay={true}
@@ -667,11 +685,178 @@ Array [
 exports[`Storyshots Meetings/Webex Meeting Loading 1`] = `
 Array [
   <div
-    className="wxc-meeting"
+    style={
+      Object {
+        "height": "100%",
+        "min-height": "25rem",
+        "position": "relative",
+        "width": "100%",
+      }
+    }
   >
-    <i
-      className="md-spinner md-spinner--36 md-spinner--black"
-    />
+    <div
+      className="wxc-meeting"
+    >
+      <i
+        className="md-spinner md-spinner--36 md-spinner--black"
+      />
+    </div>
+    <div
+      style={
+        Object {
+          "bottom": "1rem",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+        }
+      }
+    >
+      <div
+        className="wxc-meeting-control-bar"
+      >
+        <button
+          alt="Show settings panel"
+          aria-label="Show settings panel"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-settings_32"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Unmute"
+          aria-label="Unmute"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-microphone-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Start video"
+          aria-label="Start video"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-camera-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Join meeting"
+          aria-label="Join meeting"
+          aria-pressed={null}
+          className="md-button md-button--52 md-button--green"
+          data-md-event-key="md-button-0"
+          data-md-keyboard-key="join-meeting"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          style={
+            Object {
+              "style": Object {},
+            }
+          }
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="md-button__children"
+            style={
+              Object {
+                "opacity": "1",
+              }
+            }
+          >
+            Join meeting
+          </span>
+        </button>
+      </div>
+    </div>
   </div>,
   <video
     autoPlay={true}
@@ -699,220 +884,242 @@ Array [
 exports[`Storyshots Meetings/Webex Meeting Waiting For Others 1`] = `
 Array [
   <div
-    className="wxc-meeting wxc-meeting-active"
+    style={
+      Object {
+        "height": "100%",
+        "min-height": "25rem",
+        "position": "relative",
+        "width": "100%",
+      }
+    }
   >
     <div
-      className="wxc-in-meeting"
+      className="wxc-meeting"
     >
       <div
-        className="wxc-remote-media remote-media-in-meeting"
+        className="wxc-in-meeting"
       >
-        <h4>
-          Waiting for others to join...
-        </h4>
-      </div>
-      <div
-        className="wxc-local-media local-media-in-meeting"
-      >
-        <video
-          autoPlay={true}
-          playsInline={true}
-        />
-      </div>
-      <div
-        className="share-notice"
-      >
-        You're sharing your screen
+        <div
+          className="wxc-remote-media remote-media-in-meeting"
+        >
+          <h4>
+            Waiting for others to join...
+          </h4>
+        </div>
+        <div
+          className="wxc-local-media local-media-in-meeting"
+        >
+          <video
+            autoPlay={true}
+            playsInline={true}
+          />
+        </div>
+        <div
+          className="share-notice"
+        >
+          You're sharing your screen
+        </div>
       </div>
     </div>
     <div
-      className="wxc-meeting-control-bar meeting-controls-container"
+      style={
+        Object {
+          "bottom": "1rem",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+        }
+      }
     >
-      <button
-        alt="Show settings panel"
-        aria-label="Show settings panel"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
+      <div
+        className="wxc-meeting-control-bar"
       >
-        <span
-          className="md-button__children"
+        <button
+          alt="Show settings panel"
+          aria-label="Show settings panel"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-settings_32"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Mute"
-        aria-label="Mute"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-settings_32"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Mute"
+          aria-label="Mute"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-microphone-muted_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Stop video"
-        aria-label="Stop video"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-microphone-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Stop video"
+          aria-label="Stop video"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-camera-muted_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Stop Sharing"
-        aria-label="Stop Sharing"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56 md-button--red"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-camera-muted_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Stop Sharing"
+          aria-label="Stop Sharing"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-share-screen-presence-stroke_26"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
-      <button
-        alt="Leave"
-        aria-label="Leave"
-        aria-pressed={null}
-        className="md-button md-button--circle md-button--56 md-button--red"
-        data-md-event-key="md-button-0"
-        disabled={false}
-        id="md-button-0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "style": Object {},
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-share-screen-presence-stroke_26"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+        <button
+          alt="Leave"
+          aria-label="Leave"
+          aria-pressed={null}
+          className="md-button md-button--circle md-button--56 md-button--red"
+          data-md-event-key="md-button-0"
+          disabled={false}
+          id="md-button-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
           style={
             Object {
-              "opacity": "1",
+              "style": Object {},
             }
           }
+          tabIndex={0}
+          type="button"
         >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-cancel_28"
+          <span
+            className="md-button__children"
             style={
               Object {
-                "fontSize": 28,
+                "opacity": "1",
               }
             }
-          />
-        </span>
-      </button>
+          >
+            <i
+              aria-label={null}
+              className="md-icon icon icon-cancel_28"
+              style={
+                Object {
+                  "fontSize": 28,
+                }
+              }
+            />
+          </span>
+        </button>
+      </div>
     </div>
   </div>,
   <video


### PR DESCRIPTION
In order to display the meeting controls under both the meeting and roster components in the WebexMeeting widget, the meeting component is refactored in the sense of no longer rendering the controls in this place.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-233369

Depends on: #239 