### PR TITLE
refactor(MeetingsJsonAdapter): implement each JSON adapter meeting control in its own file

### DIFF
--- a/src/adapters/MeetingsJSONAdapter/controls/DisabledJoinControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/DisabledJoinControl.js
@@ -1,0 +1,31 @@
+import {Observable} from 'rxjs';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class DisabledJoinControl extends MeetingControl {
+  /**
+   * Returns an observable that emits the display data of a disabled meeting control.
+   *
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  // eslint-disable-next-line class-methods-use-this
+  display() {
+    return Observable.create((observer) => {
+      observer.next({
+        ID: this.ID,
+        text: 'Join meeting',
+        tooltip: 'Join meeting',
+        state: MeetingControlState.DISABLED,
+      });
+
+      observer.complete();
+    });
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/DisabledMuteAudioControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/DisabledMuteAudioControl.js
@@ -1,0 +1,31 @@
+import {Observable} from 'rxjs';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class DisabledMuteAudioControl extends MeetingControl {
+  /**
+   * Returns an observable that emits the display data of a disabled meeting control.
+   *
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  // eslint-disable-next-line class-methods-use-this
+  display() {
+    return Observable.create((observer) => {
+      observer.next({
+        ID: this.ID,
+        icon: 'microphone_28',
+        tooltip: 'Mute disabled',
+        state: MeetingControlState.DISABLED,
+      });
+
+      observer.complete();
+    });
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/JoinControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/JoinControl.js
@@ -1,0 +1,41 @@
+import {Observable} from 'rxjs';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class JoinControl extends MeetingControl {
+  /**
+   * Joins the meeting by adding remote media streams.
+   * Used by "join-meeting" meeting control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to join
+   */
+  async action(meetingID) {
+    await this.adapter.joinMeeting(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the join meeting control.
+   *
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  // eslint-disable-next-line class-methods-use-this
+  display() {
+    return Observable.create((observer) => {
+      observer.next({
+        ID: this.ID,
+        text: 'Join meeting',
+        tooltip: 'Join meeting',
+        state: MeetingControlState.ACTIVE,
+      });
+
+      observer.complete();
+    });
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/JoinWithoutCameraControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/JoinWithoutCameraControl.js
@@ -1,0 +1,39 @@
+import {Observable} from 'rxjs';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class JoinWithoutCameraControl extends MeetingControl {
+  /**
+   * Joins the meeting without camera
+   *
+   * @param {string} meetingID  Id of the meeting for which to join
+   */
+  async action(meetingID) {
+    await this.adapter.joinMeetingWithoutCamera(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the join meeting without camera control.
+   *
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  // eslint-disable-next-line class-methods-use-this
+  display() {
+    return Observable.create((observer) => {
+      observer.next({
+        ID: this.ID,
+        text: 'Join without camera',
+        tooltip: 'Join without camera',
+        state: MeetingControlState.ACTIVE,
+      });
+
+      observer.complete();
+    });
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/JoinWithoutMicrophoneControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/JoinWithoutMicrophoneControl.js
@@ -1,0 +1,38 @@
+import {Observable} from 'rxjs';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class JoinWithoutMicrophoneControl extends MeetingControl {
+  /**
+   * Joins the meeting without microphone
+   *
+   * @param {string} meetingID  Id of the meeting for which to join
+   */
+  async action(meetingID) {
+    await this.adapter.joinMeetingWithoutMicrophone(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the join meeting without microphone control.
+   *
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  // eslint-disable-next-line class-methods-use-this
+  display() {
+    return Observable.create((observer) => {
+      observer.next({
+        ID: this.ID,
+        text: 'Join without audio',
+        tooltip: 'Join without audio',
+      });
+
+      observer.complete();
+    });
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/LeaveControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/LeaveControl.js
@@ -1,0 +1,41 @@
+import {Observable} from 'rxjs';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class LeaveControl extends MeetingControl {
+  /**
+   * Leaves the meeting and removes the remote media streams.
+   * Used by "leave-meeting" meeting control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to leave
+   */
+  async action(meetingID) {
+    await this.adapter.leaveMeeting(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the leave meeting control.
+   *
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  // eslint-disable-next-line class-methods-use-this
+  display() {
+    return Observable.create((observer) => {
+      observer.next({
+        ID: this.ID,
+        icon: 'cancel_28',
+        tooltip: 'Leave',
+        state: MeetingControlState.ACTIVE,
+      });
+
+      observer.complete();
+    });
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/MeetingControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/MeetingControl.js
@@ -1,0 +1,12 @@
+export default class MeetingControl {
+  /**
+   * Creates a new instance of the MeetingControl.
+   *
+   * @param {object} adapter  Meeting adapter object
+   * @param {string} controlID  The id of the control
+   */
+  constructor(adapter, controlID) {
+    this.adapter = adapter;
+    this.ID = controlID;
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/MuteAudioControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/MuteAudioControl.js
@@ -1,0 +1,50 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class MuteAudioControl extends MeetingControl {
+  /**
+   * Toggles muting the local audio media stream track.
+   * Used by "mute-audio" meeting control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to mute local audio
+   */
+  async action(meetingID) {
+    await this.adapter.toggleMuteAudio(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the audio mute control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to update display
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  display(meetingID) {
+    const unmuted = {
+      ID: this.ID,
+      icon: 'microphone-muted_28',
+      tooltip: 'Mute',
+      state: MeetingControlState.INACTIVE,
+    };
+    const muted = {
+      ID: this.ID,
+      icon: 'microphone-muted_28',
+      tooltip: 'Unmute',
+      state: MeetingControlState.ACTIVE,
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map((meeting) => !!meeting.localAudio),
+      distinctUntilChanged(),
+      map((localAudioExists) => (localAudioExists ? unmuted : muted)),
+    );
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/MuteVideoControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/MuteVideoControl.js
@@ -1,0 +1,52 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class MuteVideoControl extends MeetingControl {
+  /**
+   * Toggles muting the local audio media stream track.
+   * Used by "mute-video" meeting control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to mute local video
+   */
+  async action(meetingID) {
+    await this.adapter.toggleMuteVideo(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the video mute control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to update display
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  display(meetingID) {
+    const muted = {
+      ID: this.ID,
+      icon: 'camera-muted_28',
+      tooltip: 'Start video',
+      state: MeetingControlState.ACTIVE,
+      text: null,
+    };
+    const unmuted = {
+      ID: this.ID,
+      icon: 'camera-muted_28',
+      tooltip: 'Stop video',
+      state: MeetingControlState.INACTIVE,
+      text: null,
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map((meeting) => !!meeting.localVideo),
+      distinctUntilChanged(),
+      map((localVideoExists) => (localVideoExists ? unmuted : muted)),
+    );
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/RosterControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/RosterControl.js
@@ -1,0 +1,51 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class RosterControl extends MeetingControl {
+  /**
+   * Toggles the roster display flag of a meeting.
+   *
+   * @param {string} meetingID  Id of the meeting for which to update display
+   */
+  async action(meetingID) {
+    await this.adapter.toggleRoster(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of a roster control.
+   *
+   * @param {string} meetingID  Id of the meeting to toggle roster
+   * @returns {Observable.<MeetingControlDisplay>} Observable stream that emits display data of the roster control
+   */
+  display(meetingID) {
+    const active = {
+      ID: this.ID,
+      icon: 'participant-list_28',
+      tooltip: 'Hide participants panel',
+      state: MeetingControlState.ACTIVE,
+      text: 'Participants',
+    };
+    const inactive = {
+      ID: this.ID,
+      icon: 'participant-list_28',
+      tooltip: 'Show participants panel',
+      state: MeetingControlState.INACTIVE,
+      text: 'Participants',
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map((meeting) => !!meeting.showRoster),
+      distinctUntilChanged(),
+      map((showRosterExists) => (showRosterExists ? active : inactive)),
+    );
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/SettingsControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SettingsControl.js
@@ -1,0 +1,51 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class SettingsControl extends MeetingControl {
+  /**
+   * Toggles the settings display flag of a meeting.
+   *
+   * @param {string} meetingID  Id of the meeting for which to toggle the settings flag
+   */
+  async action(meetingID) {
+    await this.adapter.toggleSettings(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of a settings control.
+   *
+   * @param {string} meetingID  Id of the meeting to toggle settings
+   * @returns {Observable.<MeetingControlDisplay>} Observable stream that emits display data of the settings control
+   */
+  display(meetingID) {
+    const active = {
+      ID: this.ID,
+      icon: 'settings_32',
+      tooltip: 'Hide settings panel',
+      state: MeetingControlState.ACTIVE,
+      text: 'Settings',
+    };
+    const inactive = {
+      ID: this.ID,
+      icon: 'settings_32',
+      tooltip: 'Show settings panel',
+      state: MeetingControlState.INACTIVE,
+      text: 'Settings',
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map((meeting) => !!meeting.showSettings),
+      distinctUntilChanged(),
+      map((showSettingsExists) => (showSettingsExists ? active : inactive)),
+    );
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/ShareControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/ShareControl.js
@@ -1,0 +1,49 @@
+import {Observable} from 'rxjs';
+import {map, distinctUntilChanged} from 'rxjs/operators';
+import {MeetingControlState} from '@webex/component-adapter-interfaces';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class ShareControl extends MeetingControl {
+  /**
+   * Handles the starting and stopping of the local screen share.
+   *
+   * @param {string} meetingID  Id of the meeting for which to update display
+   */
+  async action(meetingID) {
+    await this.adapter.handleLocalShare(meetingID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the share screen control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to update display
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  display(meetingID) {
+    const inactive = {
+      ID: this.ID,
+      icon: 'share-screen-presence-stroke_26',
+      tooltip: 'Start Sharing',
+      state: MeetingControlState.INACTIVE,
+    };
+    const active = {
+      ID: this.ID,
+      icon: 'share-screen-presence-stroke_26',
+      tooltip: 'Stop Sharing',
+      state: MeetingControlState.ACTIVE,
+    };
+
+    return this.adapter.getMeeting(meetingID).pipe(
+      map((meeting) => !!meeting.localShare),
+      distinctUntilChanged(),
+      map((localShareExists) => (localShareExists ? active : inactive)),
+    );
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchCameraControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchCameraControl.js
@@ -1,0 +1,79 @@
+import {concat, Observable, defer} from 'rxjs';
+import {
+  map, concatMap, distinctUntilChanged, distinctUntilKeyChanged,
+} from 'rxjs/operators';
+import MeetingControl from './MeetingControl';
+
+/**
+ * Display options of a meeting control.
+ *
+ * @external MeetingControlDisplay
+ * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
+ */
+
+export default class SwitchCameraControl extends MeetingControl {
+  /**
+   * Switches the camera control.
+   *
+   * @param {string} meetingID  Id of the meeting for which to switch camera
+   * @param {string} cameraID  Id of the camera device to switch to
+   */
+  async action(meetingID, cameraID) {
+    await this.adapter.switchCamera(meetingID, cameraID);
+  }
+
+  /**
+   * Returns an observable that emits the display data of the switch camera control.
+   *
+   * @param {string} meetingID  Id of the meeting to switch camera
+   * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
+   */
+  display(meetingID) {
+    const meeting = this.adapter.fetchMeeting(meetingID);
+    const availableCameras$ = defer(() => this.adapter.getAvailableDevices('videoinput'));
+
+    const initialControl$ = new Observable((observer) => {
+      if (meeting) {
+        observer.next({
+          ID: this.ID,
+          tooltip: 'Video Devices',
+          options: null,
+          selected: null,
+        });
+        observer.complete();
+      } else {
+        observer.error(new Error(`Could not find meeting with ID "${meetingID}" to add a switch camera control`));
+      }
+    });
+
+    const controlWithOptions$ = initialControl$.pipe(
+      concatMap((control) => availableCameras$.pipe(
+        map((availableCameras) => ({
+          ...control,
+          options: (availableCameras || []) && availableCameras.map((camera) => ({
+            value: camera.deviceId,
+            label: camera.label,
+            camera,
+          })),
+        })),
+      )),
+    );
+
+    const controlFromMeeting$ = controlWithOptions$.pipe(
+      concatMap((control) => this.adapter.getMeeting(meetingID).pipe(
+        distinctUntilKeyChanged('cameraID'),
+        map((updatedMeeting) => ({
+          ...control,
+          selected: updatedMeeting.cameraID,
+        })),
+      )),
+    );
+
+    return concat(initialControl$, controlWithOptions$, controlFromMeeting$).pipe(
+      distinctUntilChanged((prev, curr) => (
+        prev.selected === curr.selected
+        && prev.options === curr.options
+      )),
+    );
+  }
+}

--- a/src/adapters/MeetingsJSONAdapter/controls/index.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/index.js
@@ -1,0 +1,13 @@
+export {default as DisabledJoinControl} from './DisabledJoinControl';
+export {default as DisabledMuteAudioControl} from './DisabledMuteAudioControl';
+export {default as JoinControl} from './JoinControl';
+export {default as JoinWithoutCameraControl} from './JoinWithoutCameraControl';
+export {default as JoinWithoutMicrophoneControl} from './JoinWithoutMicrophoneControl';
+export {default as LeaveControl} from './LeaveControl';
+export {default as MeetingControl} from './MeetingControl';
+export {default as MuteAudioControl} from './MuteAudioControl';
+export {default as MuteVideoControl} from './MuteVideoControl';
+export {default as RosterControl} from './RosterControl';
+export {default as SettingsControl} from './SettingsControl';
+export {default as ShareControl} from './ShareControl';
+export {default as SwitchCameraControl} from './SwitchCameraControl';


### PR DESCRIPTION
For better encapsulation and code that is easier to maintain, the control functions (display & action) have been moved from the main meetings adapter file to individual files that are easier to read and maintain (eg. src/MeetingsSDKAdapter/JoinControl.js).

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-242542