### PR TITLE
fix(package): update component adapter interfaces to v1.18.0﻿

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11481,9 +11481,9 @@
       }
     },
     "@webex/component-adapter-interfaces": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@webex/component-adapter-interfaces/-/component-adapter-interfaces-1.17.0.tgz",
-      "integrity": "sha512-KdTY9xKl0+00uO1D+5jWaE1Y2z7DyaZH9L+6+LaFc17O7ptSgASUI9SHItHmIUIqRh1SkIPNNfcpUNbMllQsxA=="
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@webex/component-adapter-interfaces/-/component-adapter-interfaces-1.18.0.tgz",
+      "integrity": "sha512-fwjTv9NSZF8J2mGnQzj0eXtssMDLexNFqrtmaDceyVxvRB5dvYxNV9frqq/qwcdsJgXgT4gk9LyUNjP/HrCadA=="
     },
     "@webpack-contrib/schema-utils": {
       "version": "1.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@juggle/resize-observer": "^3.2.0",
-    "@webex/component-adapter-interfaces": "^1.17.0",
+    "@webex/component-adapter-interfaces": "^1.18.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.15.0"
   },


### PR DESCRIPTION
This PR is about updating the component-adapter-interfaces version to v1.18.0﻿.