### PR TITLE
fix(MeetingsJsonAdapter): ignore media devices without an id and use device id as fallback label

### DIFF
--- a/src/adapters/MeetingsJSONAdapter.js
+++ b/src/adapters/MeetingsJSONAdapter.js
@@ -335,7 +335,7 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
 
     try {
       devices = await navigator.mediaDevices.enumerateDevices();
-      devices = devices.filter((device) => device.kind === type);
+      devices = devices.filter((device) => device.kind === type && device.deviceId);
     } catch (reason) {
       // eslint-disable-next-line no-console
       console.error('Meetings JSON adapter can not enumerate media devices', reason);

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchCameraControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchCameraControl.js
@@ -55,7 +55,7 @@ export default class SwitchCameraControl extends MeetingControl {
           ...control,
           options: (availableCameras || []) && availableCameras.map((camera) => ({
             value: camera.deviceId,
-            label: camera.label,
+            label: camera.label || `Camera-${camera.deviceId}`,
             camera,
           })),
         })),

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
@@ -56,7 +56,7 @@ export default class SwitchMicrophoneControl extends MeetingControl {
           ...control,
           options: (availableMicrophones || []) && availableMicrophones.map((microphone) => ({
             value: microphone.deviceId,
-            label: microphone.label,
+            label: microphone.label || `Microphone-${microphone.deviceId}`,
             microphone,
           })),
         })),


### PR DESCRIPTION
This PR is fixing the bug where the display name of the media devices is not shown while permission is not granted by adding a default display name.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-245970