### PR TITLE
refactor(MeetingsJsonAdapter): add "proceed without device" controls

### DIFF
--- a/src/adapters/MeetingsJSONAdapter.js
+++ b/src/adapters/MeetingsJSONAdapter.js
@@ -5,11 +5,11 @@ import {MeetingsAdapter, MeetingState} from '@webex/component-adapter-interfaces
 import DisabledJoinControl from './MeetingsJSONAdapter/controls/DisabledJoinControl';
 import DisabledMuteAudioControl from './MeetingsJSONAdapter/controls/DisabledMuteAudioControl';
 import JoinControl from './MeetingsJSONAdapter/controls/JoinControl';
-import JoinWithoutCameraControl from './MeetingsJSONAdapter/controls/JoinWithoutCameraControl';
-import JoinWithoutMicrophoneControl from './MeetingsJSONAdapter/controls/JoinWithoutMicrophoneControl';
 import LeaveControl from './MeetingsJSONAdapter/controls/LeaveControl';
 import MuteAudioControl from './MeetingsJSONAdapter/controls/MuteAudioControl';
 import MuteVideoControl from './MeetingsJSONAdapter/controls/MuteVideoControl';
+import ProceedWithoutCameraControl from './MeetingsJSONAdapter/controls/ProceedWithoutCameraControl';
+import ProceedWithoutMicrophoneControl from './MeetingsJSONAdapter/controls/ProceedWithoutMicrophoneControl';
 import RosterControl from './MeetingsJSONAdapter/controls/RosterControl';
 import SettingsControl from './MeetingsJSONAdapter/controls/SettingsControl';
 import ShareControl from './MeetingsJSONAdapter/controls/ShareControl';
@@ -17,17 +17,17 @@ import SwitchCameraControl from './MeetingsJSONAdapter/controls/SwitchCameraCont
 import SwitchMicrophoneControl from './MeetingsJSONAdapter/controls/SwitchMicrophoneControl';
 
 // Meeting control names
-export const MUTE_AUDIO_CONTROL = 'mute-audio';
-export const MUTE_VIDEO_CONTROL = 'mute-video';
-export const SHARE_CONTROL = 'share-screen';
-export const JOIN_CONTROL = 'join-meeting';
-export const JOIN_WITHOUT_CAMERA_CONTROL = 'join-without-camera';
-export const JOIN_WITHOUT_MICROPHONE_CONTROL = 'join-without-microphone';
-export const LEAVE_CONTROL = 'leave-meeting';
 export const DISABLED_MUTE_AUDIO_CONTROL = 'disabled-mute-audio';
 export const DISABLED_JOIN_CONTROL = 'disabled-join-meeting';
+export const JOIN_CONTROL = 'join-meeting';
+export const LEAVE_CONTROL = 'leave-meeting';
+export const MUTE_AUDIO_CONTROL = 'mute-audio';
+export const MUTE_VIDEO_CONTROL = 'mute-video';
+export const PROCEED_WITHOUT_CAMERA_CONTROL = 'proceed-without-camera';
+export const PROCEED_WITHOUT_MICROPHONE_CONTROL = 'proceed-without-microphone';
 export const ROSTER_CONTROL = 'member-roster';
 export const SETTINGS_CONTROL = 'settings';
+export const SHARE_CONTROL = 'share-screen';
 export const SWITCH_CAMERA_CONTROL = 'switch-camera';
 export const SWITCH_MICROPHONE_CONTROL = 'switch-microphone';
 
@@ -123,10 +123,10 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
       [MUTE_VIDEO_CONTROL]: new MuteVideoControl(this, MUTE_VIDEO_CONTROL),
       [SHARE_CONTROL]: new ShareControl(this, SHARE_CONTROL),
       [JOIN_CONTROL]: new JoinControl(this, JOIN_CONTROL),
-      [JOIN_WITHOUT_CAMERA_CONTROL]:
-        new JoinWithoutCameraControl(this, JOIN_WITHOUT_CAMERA_CONTROL),
-      [JOIN_WITHOUT_MICROPHONE_CONTROL]:
-        new JoinWithoutMicrophoneControl(this, JOIN_WITHOUT_MICROPHONE_CONTROL),
+      [PROCEED_WITHOUT_CAMERA_CONTROL]:
+        new ProceedWithoutCameraControl(this, PROCEED_WITHOUT_CAMERA_CONTROL),
+      [PROCEED_WITHOUT_MICROPHONE_CONTROL]:
+        new ProceedWithoutMicrophoneControl(this, PROCEED_WITHOUT_MICROPHONE_CONTROL),
       [LEAVE_CONTROL]: new LeaveControl(this, LEAVE_CONTROL),
       [DISABLED_MUTE_AUDIO_CONTROL]:
         new DisabledMuteAudioControl(this, DISABLED_MUTE_AUDIO_CONTROL),
@@ -189,6 +189,8 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
           state: null,
           cameraID: null,
           microphoneID: null,
+          videoPermission: null,
+          audioPermission: null,
         });
       } else if (this.fetchMeeting(ID)) {
         const meeting = this.fetchMeeting(ID);
@@ -239,21 +241,27 @@ export default class MeetingsJSONAdapter extends MeetingsAdapter {
   }
 
   /**
-   * Joins the meeting without camera
+   * Allows user to join the meeting without allowing camera access
    *
    * @param {string} ID  Id of the meeting for which to join
    */
-  async joinMeetingWithoutCamera(ID) {
-    await this.updateMeeting(ID, () => {});
+  async ignoreVideoAccessPrompt(ID) {
+    await this.updateMeeting(ID, async (meeting) => ({
+      ...meeting,
+      videoPermission: 'IGNORED',
+    }));
   }
 
   /**
-   * Joins the meeting without microphone
+   * Allows user to join the meeting without allowing microphone access
    *
    * @param {string} ID  Id of the meeting for which to join
    */
-  async joinMeetingWithoutMicrophone(ID) {
-    await this.updateMeeting(ID, () => {});
+  async ignoreAudioAccessPrompt(ID) {
+    await this.updateMeeting(ID, async (meeting) => ({
+      ...meeting,
+      audioPermission: 'IGNORED',
+    }));
   }
 
   /**

--- a/src/adapters/MeetingsJSONAdapter/controls/ProceedWithoutCameraControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/ProceedWithoutCameraControl.js
@@ -8,18 +8,18 @@ import MeetingControl from './MeetingControl';
  * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
  */
 
-export default class JoinWithoutCameraControl extends MeetingControl {
+export default class ProceedWithoutCameraControl extends MeetingControl {
   /**
    * Joins the meeting without camera
    *
    * @param {string} meetingID  Id of the meeting for which to join
    */
   async action(meetingID) {
-    await this.adapter.joinMeetingWithoutCamera(meetingID);
+    await this.adapter.ignoreVideoAccessPrompt(meetingID);
   }
 
   /**
-   * Returns an observable that emits the display data of the join meeting without camera control.
+   * Returns an observable that emits the display data of the meeting without camera control.
    *
    * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
    */
@@ -28,8 +28,8 @@ export default class JoinWithoutCameraControl extends MeetingControl {
     return Observable.create((observer) => {
       observer.next({
         ID: this.ID,
-        text: 'Join without camera',
-        tooltip: 'Join without camera',
+        text: 'Proceed without camera',
+        tooltip: 'Proceed without camera',
         state: MeetingControlState.ACTIVE,
       });
 

--- a/src/adapters/MeetingsJSONAdapter/controls/ProceedWithoutMicrophoneControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/ProceedWithoutMicrophoneControl.js
@@ -8,18 +8,18 @@ import MeetingControl from './MeetingControl';
  * @see {@link https://github.com/webex/component-adapter-interfaces/blob/master/src/MeetingsAdapter.js#L58}
  */
 
-export default class JoinWithoutMicrophoneControl extends MeetingControl {
+export default class ProceedWithoutMicrophoneControl extends MeetingControl {
   /**
    * Joins the meeting without microphone
    *
    * @param {string} meetingID  Id of the meeting for which to join
    */
   async action(meetingID) {
-    await this.adapter.joinMeetingWithoutMicrophone(meetingID);
+    await this.adapter.ignoreAudioAccessPrompt(meetingID);
   }
 
   /**
-   * Returns an observable that emits the display data of the join meeting without microphone control.
+   * Returns an observable that emits the display data of the meeting without microphone control.
    *
    * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
    */
@@ -28,8 +28,8 @@ export default class JoinWithoutMicrophoneControl extends MeetingControl {
     return Observable.create((observer) => {
       observer.next({
         ID: this.ID,
-        text: 'Join without audio',
-        tooltip: 'Join without audio',
+        text: 'Proceed without audio',
+        tooltip: 'Proceed without audio',
       });
 
       observer.complete();

--- a/src/adapters/MeetingsJSONAdapter/controls/index.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/index.js
@@ -1,12 +1,12 @@
 export {default as DisabledJoinControl} from './DisabledJoinControl';
 export {default as DisabledMuteAudioControl} from './DisabledMuteAudioControl';
 export {default as JoinControl} from './JoinControl';
-export {default as JoinWithoutCameraControl} from './JoinWithoutCameraControl';
-export {default as JoinWithoutMicrophoneControl} from './JoinWithoutMicrophoneControl';
 export {default as LeaveControl} from './LeaveControl';
 export {default as MeetingControl} from './MeetingControl';
 export {default as MuteAudioControl} from './MuteAudioControl';
 export {default as MuteVideoControl} from './MuteVideoControl';
+export {default as ProceedWithoutCameraControl} from './ProceedWithoutCameraControl';
+export {default as ProceedWithoutMicrophoneControl} from './ProceedWithoutMicrophoneControl';
 export {default as RosterControl} from './RosterControl';
 export {default as SettingsControl} from './SettingsControl';
 export {default as ShareControl} from './ShareControl';

--- a/src/components/WebexMediaAccess/WebexMediaAccess.jsx
+++ b/src/components/WebexMediaAccess/WebexMediaAccess.jsx
@@ -9,13 +9,13 @@ const SCREENS = {
     icon: 'icon-camera_36',
     title: 'Allow access to camera',
     message: 'when your browser asks to let Webex use your camera for this video call',
-    control: 'join-without-camera',
+    control: 'proceed-without-camera',
   },
   microphone: {
     icon: 'icon-microphone_36',
     title: 'Allow access to microphone',
     message: 'when your browser asks to let Webex use your microphone for this video call',
-    control: 'join-without-microphone',
+    control: 'proceed-without-microphone',
   },
 };
 

--- a/src/components/WebexMediaAccess/__snapshots__/WebexMediaAccess.stories.storyshot
+++ b/src/components/WebexMediaAccess/__snapshots__/WebexMediaAccess.stories.storyshot
@@ -33,12 +33,12 @@ Array [
       when your browser asks to let Webex use your camera for this video call
     </p>
     <button
-      alt="Join without camera"
-      aria-label="Join without camera"
+      alt="Proceed without camera"
+      aria-label="Proceed without camera"
       aria-pressed={null}
       className="md-button md-button--52 md-button--green wxc-meeting-control"
       data-md-event-key="md-button-0"
-      data-md-keyboard-key="join-without-camera"
+      data-md-keyboard-key="proceed-without-camera"
       disabled={false}
       id="md-button-0"
       onClick={[Function]}
@@ -59,7 +59,7 @@ Array [
           }
         }
       >
-        Join without camera
+        Proceed without camera
       </span>
     </button>
   </div>,
@@ -119,12 +119,12 @@ Array [
       when your browser asks to let Webex use your microphone for this video call
     </p>
     <button
-      alt="Join without audio"
-      aria-label="Join without audio"
+      alt="Proceed without audio"
+      aria-label="Proceed without audio"
       aria-pressed={null}
       className="md-button md-button--52 md-button--green wxc-meeting-control"
       data-md-event-key="md-button-0"
-      data-md-keyboard-key="join-without-audio"
+      data-md-keyboard-key="proceed-without-audio"
       disabled={false}
       id="md-button-0"
       onClick={[Function]}
@@ -145,7 +145,7 @@ Array [
           }
         }
       >
-        Join without audio
+        Proceed without audio
       </span>
     </button>
   </div>,


### PR DESCRIPTION
Refactor joinWithoutCameraControl and joinWithoutMicrophoneControl to proceedWithoutCamera/Microphone, as the user will not be joined in the meeting, it just consents that accepts to proceed without camera or microphone during the meeting

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-245167