### PR TITLE
fix(WebexMeetingInfo): add margin bottom to meeting title

### DIFF
--- a/src/components/WebexInterstitialMeeting/WebexInterstitialMeeting.scss
+++ b/src/components/WebexInterstitialMeeting/WebexInterstitialMeeting.scss
@@ -26,4 +26,8 @@
     min-height: 0;
     align-self: stretch;
   }
+
+  .interstitial-meeting-info {
+    margin-bottom: 1rem;
+  }
 }

--- a/src/components/WebexMeetingInfo/WebexMeetingInfo.scss
+++ b/src/components/WebexMeetingInfo/WebexMeetingInfo.scss
@@ -8,6 +8,7 @@
 
   h2 {
     font-size: 1.5rem;
+    margin: 0;
   }
 
   h3 {


### PR DESCRIPTION
This PR fixes the bug where meeting title is placed right on top of the video in interstitial meeting.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-266336