### PR TITLE
fix(Modal): set size for the "close" icon in the settings window

### DIFF
--- a/src/components/generic/Modal/Modal.jsx
+++ b/src/components/generic/Modal/Modal.jsx
@@ -33,7 +33,7 @@ export default function Modal({
       <div className="modal-content">
         <div className="modal-header">
           {title && <h3 className="modal-title">{title}</h3>}
-          {onClose && <Button type="ghost" onClick={onClose}><Icon name="cancel" /></Button>}
+          {onClose && <Button type="ghost" onClick={onClose}><Icon name="cancel" size="16" /></Button>}
         </div>
         <div className="modal-body">{children}</div>
       </div>


### PR DESCRIPTION
Fixes
<img width="196" alt="image-2021-09-17-15-27-32-005" src="https://user-images.githubusercontent.com/6610308/134290503-7f896d70-c46f-4e2f-92d7-665d144cda30.png">

Closing modal icon should be 16x16