### PR TITLE
fix(WebexMeetingControl): add a correct property name for font family to webex control styling file

### DIFF
--- a/src/components/WebexMeetingControl/WebexMeetingControl.scss
+++ b/src/components/WebexMeetingControl/WebexMeetingControl.scss
@@ -1,7 +1,7 @@
 .#{$WEBEX_COMPONENTS_CLASS_PREFIX}-meeting-control {
   display: inline-block;
   color: var(--wxc-text-color);
-  font: $brand-font-regular;
+  font-family: $brand-font-regular;
 
   &.as-item {
     display: flex;


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-269357