### PR TITLE
feat(WebexMeeting): add controls prop to meeting component

### DIFF
--- a/src/components/WebexMeeting/README.md
+++ b/src/components/WebexMeeting/README.md
@@ -25,13 +25,19 @@ or run the following **NPM** command:
     const jsonAdapter = new WebexJSONAdapter(jsonData);
     ```
 
-2. Create a component instance by passing the meeting ID as a string. You then need to enclose it
+2. Create a component instance by passing the meeting ID as a string and an optional function to define custom controls for a meeting. This function should take a boolean parameter, which signifies whether the meeting is active and returns an array of control names for the meeting. The default control names are set to `['mute-audio', 'mute-video', 'settings', 'join-meeting']` if the meeting is inactive and `['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']`otherwise.
+Ensure that the control names match with the adapter implementation of the controls.
+You then need to enclose it
 within [a data provider](../WebexDataProvider/WebexDataProvider.js) that takes
 the [component data adapter](../../adapters/WebexJSONAdapter.js) that we created previously
 
     ```js
+    const controls = (isActive) => isActive
+      ? ['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']
+      : ['mute-audio', 'mute-video', 'settings', 'join-meeting'];
+
     <WebexDataProvider adapter={jsonAdapter}>
-      <WebexMeeting meetingID="meetingID"/>
+      <WebexMeeting meetingID="meetingID" controls={controls} />
     </WebexDataProvider>
     ```
 

--- a/src/components/WebexMeeting/WebexMeeting.jsx
+++ b/src/components/WebexMeeting/WebexMeeting.jsx
@@ -26,6 +26,7 @@ import {AdapterContext} from '../hooks/contexts';
  *
  * @param {object} props  Data passed to the component
  * @param {string} [props.className]  Custom CSS class to apply
+ * @param {Function} [props.controls]   Controls to display
  * @param {JSX.Element} [props.logo]  Logo
  * @param {string} [props.meetingID]  ID of the meeting
  * @param {object} [props.style]  Custom style to apply
@@ -33,6 +34,7 @@ import {AdapterContext} from '../hooks/contexts';
  */
 export default function WebexMeeting({
   className,
+  controls,
   logo,
   meetingID,
   style,
@@ -90,7 +92,7 @@ export default function WebexMeeting({
           )}
           {showToast && <Badge className="media-state-toast">{toastText}</Badge>}
         </div>
-        <WebexMeetingControlBar meetingID={ID} className="control-bar" />
+        <WebexMeetingControlBar meetingID={ID} className="control-bar" controls={controls} />
         {showSettings && (
           <Modal
             onClose={() => adapter.meetingsAdapter.toggleSettings(ID)}
@@ -113,6 +115,7 @@ export default function WebexMeeting({
 
 WebexMeeting.propTypes = {
   className: PropTypes.string,
+  controls: PropTypes.func,
   logo: PropTypes.node,
   meetingID: PropTypes.string,
   style: PropTypes.shape(),
@@ -120,6 +123,11 @@ WebexMeeting.propTypes = {
 
 WebexMeeting.defaultProps = {
   className: '',
+  controls: (isActive) => (
+    isActive
+      ? ['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']
+      : ['mute-audio', 'mute-video', 'settings', 'join-meeting']
+  ),
   logo: undefined,
   meetingID: undefined,
   style: undefined,

--- a/src/components/WebexMeetingControlBar/WebexMeetingControlBar.jsx
+++ b/src/components/WebexMeetingControlBar/WebexMeetingControlBar.jsx
@@ -217,8 +217,8 @@ WebexMeetingControlBar.defaultProps = {
   collapseRangeEnd: -1,
   controls: (isActive) => (
     isActive
-      ? ['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']
-      : ['mute-audio', 'mute-video', 'settings', 'join-meeting']
+      ? ['mute-audio', 'mute-video', 'leave-meeting']
+      : ['mute-audio', 'mute-video', 'join-meeting']
   ),
   style: undefined,
 };


### PR DESCRIPTION
In this PR it was added the controls prop in order to be able to pass a custom list of controls to WebexMeetingControlBar component coming from above. 
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-270964