### PR TITLE
feat(WebexMeeting): add collapsible controls range props to meeting component

### DIFF
--- a/src/components/WebexMeeting/README.md
+++ b/src/components/WebexMeeting/README.md
@@ -25,11 +25,11 @@ or run the following **NPM** command:
     const jsonAdapter = new WebexJSONAdapter(jsonData);
     ```
 
-2. Create a component instance by passing the meeting ID as a string and an optional function to define custom controls for a meeting. This function should take a boolean parameter, which signifies whether the meeting is active and returns an array of control names for the meeting. The default control names are set to `['mute-audio', 'mute-video', 'settings', 'join-meeting']` if the meeting is inactive and `['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']`otherwise.
+2. Create a component instance by passing the meeting ID as a string, an optional function to specify a custom list of controls for a meeting and an optional range to specify which controls can be collapsed if not enough space is available.
+The controls function receives a boolean parameter which is true when the meeting is active. It should return an array of control names (strings) corresponding to the current state of the meeting (inactive or active). The default control names `['mute-audio', 'mute-video', 'settings', 'join-meeting']` if the meeting is inactive and `['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']`otherwise.
 Ensure that the control names match with the adapter implementation of the controls.
-You then need to enclose it
-within [a data provider](../WebexDataProvider/WebexDataProvider.js) that takes
-the [component data adapter](../../adapters/WebexJSONAdapter.js) that we created previously
+The `controlsCollapseRangeStart` is a zero-based index of the first collapsible control (can be negative).
+The `controlsCollapseRangeEnd` is a zero-based index before the last collapsible control (can be negative). Negative numbers are counted from the end of the controls array. For example, if the `controlsCollapseRangeEnd` is -2, the last 2 controls won't collapse. You then need to enclose it within [a data provider](../WebexDataProvider/WebexDataProvider.js) that takes the [component data adapter](../../adapters/WebexJSONAdapter.js) that we created previously
 
     ```js
     const controls = (isActive) => isActive
@@ -37,8 +37,31 @@ the [component data adapter](../../adapters/WebexJSONAdapter.js) that we created
       : ['mute-audio', 'mute-video', 'settings', 'join-meeting'];
 
     <WebexDataProvider adapter={jsonAdapter}>
-      <WebexMeeting meetingID="meetingID" controls={controls} />
+      <WebexMeeting 
+        meetingID="meetingID"
+        controls={controls}
+        controlsCollapseRangeStart={0}
+        controlsCollapseRangeEnd={-1}
+      />
     </WebexDataProvider>
+    ```
+or, alternatively it can be used withAdapter HOC
+
+    ```js
+    const controls = (isActive) => isActive
+      ? ['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']
+      : ['mute-audio', 'mute-video', 'settings', 'join-meeting'];
+
+    const MeetingWithAdapter = withAdapter(WebexMeeting, (props) => {
+      return new WebexJSONAdapter(data); // or other adapter
+    });
+
+    <MeetingWithAdapter 
+      meetingID="meetingID"
+      controls={controls}
+      controlsCollapseRangeStart={0}
+      controlsCollapseRangeEnd={-1}
+    />
     ```
 
 The component knows how to manage its data. If anything changes in the data source that the adapter manages,

--- a/src/components/WebexMeeting/WebexMeeting.jsx
+++ b/src/components/WebexMeeting/WebexMeeting.jsx
@@ -28,6 +28,8 @@ import {AdapterContext} from '../hooks/contexts';
  * @param {object} props  Data passed to the component
  * @param {string} [props.className]  Custom CSS class to apply
  * @param {Function} [props.controls]   Controls to display
+ * @param {number} [props.controlsCollapseRangeStart=0]  Zero-based index of the first collapsible control (can be negative)
+ * @param {number} [props.controlsCollapseRangeEnd=-1]  Zero-based index before the last collapsible control (can be negative)
  * @param {JSX.Element} [props.logo]  Logo
  * @param {string} [props.meetingID]  ID of the meeting
  * @param {object} [props.style]  Custom style to apply
@@ -36,6 +38,8 @@ import {AdapterContext} from '../hooks/contexts';
 export default function WebexMeeting({
   className,
   controls,
+  controlsCollapseRangeStart,
+  controlsCollapseRangeEnd,
   logo,
   meetingID,
   style,
@@ -96,7 +100,13 @@ export default function WebexMeeting({
           )}
           {showToast && <Badge className={sc('media-state-toast')}>{toastText}</Badge>}
         </div>
-        <WebexMeetingControlBar meetingID={ID} className={sc('control-bar')} controls={controls} />
+        <WebexMeetingControlBar
+          meetingID={ID}
+          className={sc('control-bar')}
+          controls={controls}
+          collapseRangeStart={controlsCollapseRangeStart}
+          collapseRangeEnd={controlsCollapseRangeEnd}
+        />
         {settings.visible && (
           <Modal
             onClose={() => adapter.meetingsAdapter.toggleSettings(ID)}
@@ -141,6 +151,8 @@ export default function WebexMeeting({
 WebexMeeting.propTypes = {
   className: PropTypes.string,
   controls: PropTypes.func,
+  controlsCollapseRangeStart: PropTypes.number,
+  controlsCollapseRangeEnd: PropTypes.number,
   logo: PropTypes.node,
   meetingID: PropTypes.string,
   style: PropTypes.shape(),
@@ -153,6 +165,8 @@ WebexMeeting.defaultProps = {
       ? ['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']
       : ['mute-audio', 'mute-video', 'settings', 'join-meeting']
   ),
+  controlsCollapseRangeStart: 0,
+  controlsCollapseRangeEnd: -1,
   logo: undefined,
   meetingID: undefined,
   style: undefined,


### PR DESCRIPTION
In this PR were added the 'controlsCollapseRangeStart' and 'controlsCollapseRangeEnd' props that define a range used for collapsible controls.
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-272143