### PR TITLE
feat(WebexMeetingGuestAuthentication): disable start meeting when name and password are not valid

### DIFF
--- a/src/components/WebexMeetingGuestAuthentication/WebexMeetingGuestAuthentication.jsx
+++ b/src/components/WebexMeetingGuestAuthentication/WebexMeetingGuestAuthentication.jsx
@@ -38,10 +38,12 @@ export default function WebexMeetingGuestAuthentication({
   const [name, setName] = useState();
   const [password, setPassword] = useState('');
   const [nameError, setNameError] = useState();
-  const {ID} = useMeeting(meetingID);
+  const {ID, invalidPassword} = useMeeting(meetingID);
   const adapter = useContext(AdapterContext);
 
   const [cssClasses, sc] = webexComponentClasses('meeting-guest-authentication', className);
+
+  const isStartButtonDisabled = nameError || !password || invalidPassword;
 
   const joinMeeting = () => {
     adapter.meetingsAdapter.joinMeeting(ID, {name, password});
@@ -74,7 +76,7 @@ export default function WebexMeetingGuestAuthentication({
             onChange={(value) => setPassword(value)}
           />
         </label>
-        <Button type="primary" onClick={joinMeeting}>Start Meeting</Button>
+        <Button type="primary" onClick={joinMeeting} isDisabled={isStartButtonDisabled}>Start meeting</Button>
       </form>
       <div className={sc('host-text')}>
         Hosting the meeting?

--- a/src/components/WebexMeetingGuestAuthentication/__snapshots__/WebexMeetingGuestAuthentication.stories.storyshot
+++ b/src/components/WebexMeetingGuestAuthentication/__snapshots__/WebexMeetingGuestAuthentication.stories.storyshot
@@ -82,13 +82,13 @@ Array [
       </label>
       <button
         className="wxc-button wxc-button--primary"
-        disabled={false}
+        disabled={true}
         onClick={[Function]}
         style={Object {}}
         title=""
         type="button"
       >
-        Start Meeting
+        Start meeting
       </button>
     </form>
     <div


### PR DESCRIPTION
Start meeting button must be disabled when one or more of the following situations occurs:
- name is invalid;
- password is empty;
- a previous join attempt has failed because password was invalid;


https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-273394