### PR TITLE
feat(WebexSettings): disable dropdowns when no devices are available

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,6 +80,7 @@
     "newline-before-return": "error",
     "lines-around-directive": "error",
     "no-useless-call": "error",
+    "operator-linebreak": "off",
     "jsx-a11y/tabindex-no-positive": "off"
   },
   "overrides": [

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchCameraControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchCameraControl.js
@@ -1,5 +1,6 @@
 import {concat, Observable, defer} from 'rxjs';
 import {
+  first,
   map,
   concatMap,
   distinctUntilChanged,
@@ -31,7 +32,10 @@ export default class SwitchCameraControl extends MeetingControl {
    * @returns {Observable.<MeetingControlDisplay>} Observable that emits control display data
    */
   display(meetingID) {
-    const availableCameras$ = defer(() => this.adapter.getAvailableDevices('videoinput'));
+    const availableCameras$ = this.adapter.getMeeting(meetingID).pipe(
+      first(),
+      concatMap(() => defer(() => this.adapter.getAvailableDevices(meetingID, 'videoinput'))),
+    );
 
     const initialControl$ = new Observable((observer) => {
       const meeting = this.adapter.fetchMeeting(meetingID);

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
@@ -1,5 +1,6 @@
 import {concat, Observable, defer} from 'rxjs';
 import {
+  first,
   map,
   concatMap,
   distinctUntilChanged,
@@ -32,7 +33,10 @@ export default class SwitchMicrophoneControl extends MeetingControl {
    * @private
    */
   display(meetingID) {
-    const availableMicrophones$ = defer(() => this.adapter.getAvailableDevices('audioinput'));
+    const availableMicrophones$ = this.adapter.getMeeting(meetingID).pipe(
+      first(),
+      concatMap(() => defer(() => this.adapter.getAvailableDevices(meetingID, 'audioinput'))),
+    );
 
     const initialControl$ = new Observable((observer) => {
       const meeting = this.adapter.fetchMeeting(meetingID);

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchSpeakerControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchSpeakerControl.js
@@ -33,7 +33,7 @@ export default class SwitchSpeakerControl extends MeetingControl {
    * @private
    */
   display(meetingID) {
-    const availableSpeakers$ = defer(() => this.adapter.getAvailableDevices('audiooutput')).pipe(
+    const availableSpeakers$ = defer(() => this.adapter.getAvailableDevices(meetingID, 'audiooutput')).pipe(
       map((availableSpeakers) => availableSpeakers.map((speaker) => ({
         value: speaker.deviceId,
         label: speaker.label,

--- a/src/components/WebexAudioSettings/WebexAudioSettings.jsx
+++ b/src/components/WebexAudioSettings/WebexAudioSettings.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {useMeetingControl} from '../hooks';
 import webexComponentClasses from '../helpers';
+import {useMeeting} from '../hooks';
 import Title from '../generic/Title/Title';
 import WebexMeetingControl from '../WebexMeetingControl/WebexMeetingControl';
 import WebexNoMedia from '../WebexNoMedia/WebexNoMedia';
@@ -17,20 +17,20 @@ import WebexNoMedia from '../WebexNoMedia/WebexNoMedia';
  */
 export default function WebexAudioSettings({className, meetingID, style}) {
   const [cssClasses, sc] = webexComponentClasses('audio-settings', className);
-  const [, display] = useMeetingControl('switch-microphone', meetingID);
+  const {localAudio: {permission}} = useMeeting(meetingID);
 
   return (
     <div className={cssClasses} style={style}>
-      {display.options?.length !== 0
+      {(permission === 'DENIED' || permission === 'DISMISSED' || permission === 'IGNORED')
         ? (
+          <WebexNoMedia media="microphone" className={sc('no-media')} />
+        ) : (
           <>
             <Title type="subsection">Speaker</Title>
             <WebexMeetingControl type="switch-speaker" meetingID={meetingID} tabIndex={102} />
             <Title type="subsection">Microphone</Title>
             <WebexMeetingControl type="switch-microphone" meetingID={meetingID} tabIndex={103} />
           </>
-        ) : (
-          <WebexNoMedia media="microphone" className={sc('no-media')} />
         )}
     </div>
   );

--- a/src/components/WebexMeetingControl/__snapshots__/WebexMeetingControl.stories.storyshot
+++ b/src/components/WebexMeetingControl/__snapshots__/WebexMeetingControl.stories.storyshot
@@ -184,21 +184,22 @@ Array [
     className="wxc-meeting-control"
   >
     <div
-      className="wxc-select wxc-meeting-control__control-select"
+      className="wxc-select wxc-meeting-control__control-select wxc-select--disabled"
+      disabled={true}
     >
       <div
-        aria-hidden="true"
-        aria-label="Use arrow keys to navigate between camera options and hit \\"Enter\\" to select."
+        aria-label="No available cameras. Use arrow keys to navigate between camera options and hit \\"Enter\\" to select."
         className="wxc-select__selected-option "
         onClick={[Function]}
         onKeyDown={[Function]}
         role="button"
+        tabIndex={-1}
         title="Video Devices"
       >
         <span
           className="wxc-select__label"
         >
-          
+          No available cameras
         </span>
         <svg
           className="wxc-icon "

--- a/src/components/WebexSettings/__snapshots__/WebexSettings.stories.storyshot
+++ b/src/components/WebexSettings/__snapshots__/WebexSettings.stories.storyshot
@@ -65,9 +65,9 @@ Array [
           >
             <div
               className="wxc-select wxc-meeting-control__control-select"
+              disabled={false}
             >
               <div
-                aria-hidden="true"
                 aria-label="Browser Default. Use arrow keys to navigate between speaker options and hit \\"Enter\\" to select."
                 className="wxc-select__selected-option "
                 onClick={[Function]}
@@ -106,22 +106,22 @@ Array [
             className="wxc-meeting-control"
           >
             <div
-              className="wxc-select wxc-meeting-control__control-select"
+              className="wxc-select wxc-meeting-control__control-select wxc-select--disabled"
+              disabled={true}
             >
               <div
-                aria-hidden="true"
-                aria-label="Use arrow keys to navigate between microphone options and hit \\"Enter\\" to select."
+                aria-label="No available microphones. Use arrow keys to navigate between microphone options and hit \\"Enter\\" to select."
                 className="wxc-select__selected-option "
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="button"
-                tabIndex={103}
+                tabIndex={-1}
                 title="Microphone Devices"
               >
                 <span
                   className="wxc-select__label"
                 >
-                  
+                  No available microphones
                 </span>
                 <svg
                   className="wxc-icon "

--- a/src/components/WebexVideoSettings/WebexVideoSettings.jsx
+++ b/src/components/WebexVideoSettings/WebexVideoSettings.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {useMeetingControl} from '../hooks';
 import webexComponentClasses from '../helpers';
+import {useMeeting} from '../hooks';
 import Banner from '../generic/Banner/Banner';
 import Title from '../generic/Title/Title';
 import WebexLocalMedia from '../WebexLocalMedia/WebexLocalMedia';
@@ -19,12 +19,14 @@ import WebexNoMedia from '../WebexNoMedia/WebexNoMedia';
  */
 export default function WebexVideoSettings({meetingID, className, style}) {
   const [cssClasses, sc] = webexComponentClasses('video-settings', className);
-  const [, display] = useMeetingControl('switch-camera', meetingID);
+  const {localVideo: {permission}} = useMeeting(meetingID);
 
   return (
     <div className={cssClasses} style={style}>
-      {display.options?.length !== 0
+      {(permission === 'DENIED' || permission === 'DISMISSED' || permission === 'IGNORED')
         ? (
+          <WebexNoMedia media="camera" className={sc('no-media')} />
+        ) : (
           <>
             <Title type="subsection">Camera</Title>
             <WebexMeetingControl type="switch-camera" meetingID={meetingID} tabIndex={102} />
@@ -33,8 +35,6 @@ export default function WebexVideoSettings({meetingID, className, style}) {
               <Banner type="bottom">Preview</Banner>
             </div>
           </>
-        ) : (
-          <WebexNoMedia media="camera" className={sc('no-media')} />
         )}
     </div>
   );

--- a/src/components/generic/Select/Select.jsx
+++ b/src/components/generic/Select/Select.jsx
@@ -71,19 +71,18 @@ export default function Select({
   }, [expanded]);
 
   return (
-    <div className={cssClasses}>
+    <div className={cssClasses} disabled={disabled}>
       <div
         className={`${sc('selected-option')} ${expanded ? sc('expanded') : ''}`}
         onClick={() => toggleExpanded(false)}
-        aria-hidden="true"
         role="button"
-        tabIndex={tabIndex}
+        tabIndex={disabled ? -1 : tabIndex}
         title={tooltip}
         aria-label={`${label ? `${label}. ` : ''}${ariaLabel}`}
         onKeyDown={handleKeyDown}
         ref={ref}
       >
-        <span className={sc('label')}>{label || value}</span>
+        <span className={sc('label')}>{options === null ? 'Loading...' : (label || value)}</span>
         <Icon name={expanded ? 'arrow-up' : 'arrow-down'} size={13} />
       </div>
       {expanded && (

--- a/src/components/generic/Select/Select.scss
+++ b/src/components/generic/Select/Select.scss
@@ -3,39 +3,16 @@ $C: #{$WEBEX_COMPONENTS_CLASS_PREFIX}-select;
 .#{$C} {
   position: relative;
 
-  &--disabled {
-    .#{$C}__selected-option {
-      border: none;
-      background: var(--wxc-select--disabled--background);
-      color: var(--wxc-select--disabled--color);
-
-      &:hover,
-      &:active,
-      &--expended {
-        background: var(--wxc-select--disabled--background);
-        color: var(--wxc-select--disabled--color);
-      }
-
-      &:focus {
-        border: none;
-        color: var(--wxc-select--disabled--color);
-      }
-
-      svg path {
-        fill: var(--wxc-select--disabled--color)
-      }
-    }
-  }
-
   .#{$C}__selected-option {
     display: flex;
     align-items: center;
-    background: var(--wxc-select--normal--background);
-    border: var(--wcx-select--normal--border);
-    color: var(--wxc-select--normal--color);
     border-radius: 0.5rem;
     padding: 0.375rem 0.75rem;
-    cursor: pointer;
+
+    &.#{$C}__expanded {
+      background: var(--wxc-select--active--background);
+      color: var(--wxc-select--active--color);
+    }
 
     .#{$C}__label {
       flex: 1;
@@ -46,26 +23,6 @@ $C: #{$WEBEX_COMPONENTS_CLASS_PREFIX}-select;
       text-overflow: ellipsis;
       overflow: hidden;
     }
-
-    &:hover {
-      background: var(--wxc-select--hover--background);
-    }
-
-    &:active {
-      background: var(--wxc-select--active--background);
-    }
-
-    &:focus {
-      background: var(--wxc-select--focus--background);
-      border: var(--wxc-select--focus--border);
-      box-shadow: var(--wxc-select--focus--box-shadow);
-      color: var(--wxc-select--focus--color);
-    }
-
-    &.#{$C}__expanded {
-      background: var(--wxc-select--active--background);
-      color: var(--wxc-select--active--color);
-    }
   }
 
   .#{$C}__options-list {
@@ -74,6 +31,40 @@ $C: #{$WEBEX_COMPONENTS_CLASS_PREFIX}-select;
     top: calc(100% + 0.25rem);
     left: 0;
     right: 0;
+  }
+
+
+  &:not(.#{$C}--disabled) {
+    .#{$C}__selected-option {
+      background: var(--wxc-select--normal--background);
+      border: var(--wcx-select--normal--border);
+      color: var(--wxc-select--normal--color);
+      cursor: pointer;
+
+      &:hover {
+        background: var(--wxc-select--hover--background);
+      }
+
+      &:active {
+        background: var(--wxc-select--active--background);
+      }
+
+      &:focus {
+        background: var(--wxc-select--focus--background);
+        border: var(--wxc-select--focus--border);
+        box-shadow: var(--wxc-select--focus--box-shadow);
+        color: var(--wxc-select--focus--color);
+      }
+    }
+  }
+
+  &--disabled {
+    .#{$C}__selected-option {
+      background: var(--wxc-select--disabled--background);
+      border: var(--wcx-select--disabled--border);
+      color: var(--wxc-select--disabled--color);
+      cursor: default;
+    }
   }
 }
 

--- a/src/data/meetings.js
+++ b/src/data/meetings.js
@@ -21,8 +21,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID1',
@@ -49,8 +49,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID2',
@@ -77,8 +77,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID1',
@@ -105,8 +105,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID1',
@@ -133,8 +133,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID2',
@@ -161,8 +161,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID1',
@@ -189,8 +189,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: null,
@@ -217,8 +217,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: null,
@@ -245,8 +245,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: null,
@@ -275,8 +275,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID1',
@@ -289,10 +289,10 @@ export default {
     ID: 'meeting11',
     title: 'Waiting for host',
     localAudio: {
-      stream: new MediaStream(),
+      stream: null,
     },
     localVideo: {
-      stream: new MediaStream(),
+      stream: null,
     },
     localShare: {
       stream: null,
@@ -305,8 +305,8 @@ export default {
     settings: {
       visible: false,
       preview: {
-        microphone: {},
-        video: {},
+        audio: null,
+        video: null,
       },
     },
     cameraID: 'cameraID1',
@@ -333,6 +333,10 @@ export default {
     showRoster: false,
     settings: {
       visible: false,
+      preview: {
+        audio: null,
+        video: null,
+      },
     },
     cameraID: null,
     microphoneID: null,

--- a/src/themes/dark.scss
+++ b/src/themes/dark.scss
@@ -7,7 +7,6 @@
   --wxc-error-color: #{$wxc-red-40};
   --wxc-primary-background: #{$wxc-gradation-webex-dark-primary};
   --wxc-secondary-background: #{$wxc-gradation-webex-dark-secondary};
-  --wxc-error-color: #{$wxc-red-40};
   --wxc-muted-color: #{$wxc-red-50};
   --wxc-speaking-color: #{$wxc-green-40};
   --wxc-video-background: #{$wxc-white-alpha-05};
@@ -130,6 +129,7 @@
   --wxc-select--active--color: #{$wxc-white-alpha-95};
 
   --wxc-select--disabled--background: #{$wxc-white-alpha-11};
+  --wcx-select--disabled--border: 1px solid #{$wxc-white-alpha-11};
   --wxc-select--disabled--color: #{$wxc-white-alpha-40};
 
   --wxc-select--focus--background: #{$wxc-white-alpha-11};

--- a/src/themes/light.scss
+++ b/src/themes/light.scss
@@ -7,7 +7,6 @@
   --wxc-error-color: #{$wxc-red-70};
   --wxc-primary-background: #{$wxc-gradation-webex-light-primary};
   --wxc-secondary-background: #{$wxc-gradation-webex-light-secondary};
-  --wxc-error-color: #{$wxc-red-70};
   --wxc-muted-color: #{$wxc-red-60};
   --wxc-speaking-color: #{$wxc-green-60};
   --wxc-video-background: #{$wxc-white-alpha-100};
@@ -130,6 +129,7 @@
   --wxc-select--active--color: #{$wxc-black-alpha-95};
 
   --wxc-select--disabled--background: #{$wxc-black-alpha-11};
+  --wcx-select--disabled--border: 1px solid #{$wxc-black-alpha-11};
   --wxc-select--disabled--color: #{$wxc-black-alpha-40};
 
   --wxc-select--focus--background: #{$wxc-black-alpha-11};


### PR DESCRIPTION
Detects the specific media error when a media stream can not be obtained from the browser. Disables the switch camera & microphone dropdowns when there are no available devices on the system, or they exist but are disabled. Still displays the "no media" message in settings when the user has not granted access (denied, dismissed or just ignored the prompt).

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-290114