### PR TITLE
fix(hooks): make useActivity and useAdaptiveCard work if an adapter isn't yet present on the context

### DIFF
--- a/src/components/hooks/useActivity.js
+++ b/src/components/hooks/useActivity.js
@@ -18,19 +18,29 @@ import {AdapterContext} from './contexts';
  */
 export default function useActivity(activityID) {
   const [activity, setActivity] = useState({});
-  const {activitiesAdapter} = useContext(AdapterContext);
+  const adapter = useContext(AdapterContext);
+  const activitiesAdapter = adapter && adapter.activitiesAdapter;
 
   useEffect(() => {
-    const onError = (error) => {
-      throw error;
-    };
-    const subscription = activitiesAdapter.getActivity(activityID).subscribe(setActivity, onError);
+    let cleanup;
 
-    return () => {
-      subscription.unsubscribe();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (!activitiesAdapter || !activityID) {
+      setActivity({});
+      cleanup = undefined;
+    } else {
+      const onError = (error) => {
+        throw error;
+      };
+      const subscription = activitiesAdapter
+        .getActivity(activityID).subscribe(setActivity, onError);
+
+      cleanup = () => {
+        subscription.unsubscribe();
+      };
+    }
+
+    return cleanup;
+  }, [activitiesAdapter, activityID]);
 
   return activity;
 }

--- a/src/components/hooks/useAdaptiveCard.js
+++ b/src/components/hooks/useAdaptiveCard.js
@@ -17,7 +17,8 @@ import {AdapterContext} from './contexts';
  */
 export default function useAdaptiveCard(activityID) {
   const [card, setCard] = useState({});
-  const {activitiesAdapter} = useContext(AdapterContext);
+  const adapter = useContext(AdapterContext);
+  const activitiesAdapter = adapter && adapter.activitiesAdapter;
 
   useEffect(() => {
     let cleanup;


### PR DESCRIPTION
Task link: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-309971