### PR TITLE
fix(Tooltip): don't display tooltip if on devices with touch

### DIFF
--- a/src/components/generic/Tooltip/Tooltip.jsx
+++ b/src/components/generic/Tooltip/Tooltip.jsx
@@ -34,27 +34,20 @@ const Tooltip = ({
 
   useEffect(() => {
     let cleanup;
+    const isTouchDevice = ('ontouchstart' in window) ||
+         (navigator.maxTouchPoints > 0) ||
+         (navigator.msMaxTouchPoints > 0);
 
-    if (target) {
+    if (target && !isTouchDevice) {
       const show = () => setTooltipVisible(true);
       const hide = () => setTooltipVisible(false);
-
-      target.addEventListener('touchstart', show);
-      target.addEventListener('touchend', hide);
 
       target.addEventListener('mouseenter', show);
       target.addEventListener('mouseleave', hide);
 
-      target.addEventListener('click', hide);
-
       cleanup = () => {
-        target.removeEventListener('touchstart', show);
-        target.removeEventListener('touchend', hide);
-
         target.removeEventListener('mouseenter', show);
         target.removeEventListener('mouseleave', hide);
-
-        target.removeEventListener('click', hide);
       };
     }
 


### PR DESCRIPTION
Task link: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-316551
This PR removes button tooltips altogether because we could not find a fix for the tooltip misalignment on mobile. That issue is most likely caused by the fact that scroll position is affected by the address bar that hides on scroll down (only with HTTPS, not HTTP). If someone can correctly position tooltips on mobile, the mobile tooltips can be re-enabled
https://stackoverflow.com/questions/50914207/position-fixed-on-chrome-mobile-causing-issues-when-scrolling