### PR TITLE
fix: Meeting Title margin issue in in-meeting component

### DIFF
--- a/src/components/WebexInMeeting/WebexInMeeting.scss
+++ b/src/components/WebexInMeeting/WebexInMeeting.scss
@@ -46,7 +46,10 @@ $shadow-color: rgba(0, 0, 0, 0.2);
     min-height: auto;
     background: var(--wxc-secondary-video-background);
   }
-
+  .#{$C}__info {
+    margin-bottom: 1rem;
+  }
+  
   &--tablet {
     .#{$C}__local-media-in-meeting {
       @include media-preview-tablet();

--- a/src/components/WebexInterstitialMeeting/__snapshots__/WebexInterstitialMeeting.stories.storyshot
+++ b/src/components/WebexInterstitialMeeting/__snapshots__/WebexInterstitialMeeting.stories.storyshot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Meetings/Webex Interstitial Meeting Loading 1`] = `
+exports[`Storyshots Meetings/Webex In-Meeting All Media 1`] = `
 Array [
   <div
-    className="wxc wxc-interstitial-meeting"
+    className="wxc wxc-in-meeting"
     style={
       Object {
         "height": "100%",
@@ -12,51 +12,7 @@ Array [
     }
   >
     <div
-      className="wxc wxc-spinner"
-      style={
-        Object {
-          "height": 30,
-          "width": 30,
-        }
-      }
-    />
-  </div>,
-  <video
-    autoPlay={true}
-    height="0"
-    id="remote-video"
-    loop={true}
-    muted={true}
-    playsInline={true}
-    src="./video/ongoing-meeting.mp4"
-    width="0"
-  />,
-  <video
-    autoPlay={true}
-    height="0"
-    id="remote-share"
-    loop={true}
-    muted={true}
-    playsInline={true}
-    src="./video/ongoing-share.mp4"
-    width="0"
-  />,
-]
-`;
-
-exports[`Storyshots Meetings/Webex Interstitial Meeting Video Disabled 1`] = `
-Array [
-  <div
-    className="wxc wxc-interstitial-meeting"
-    style={
-      Object {
-        "height": "100%",
-        "width": "100%",
-      }
-    }
-  >
-    <div
-      className="wxc-interstitial-meeting__media-container"
+      className="wxc-in-meeting__media-container"
       style={
         Object {
           "maxWidth": "none",
@@ -64,45 +20,65 @@ Array [
       }
     >
       <div
-        className="wxc wxc-meeting-info wxc-interstitial-meeting__info"
-      >
-        <h5
-          className="wxc wxc-title wxc-meeting-info__title wxc-title--subsection"
-          style={Object {}}
-        >
-          Video Disabled
-        </h5>
-      </div>
-      <div
-        className="wxc-interstitial-meeting__interstitial-media-container"
+        className="wxc wxc-meeting-info wxc-in-meeting__info"
       >
         <div
-          className="wxc wxc-local-media wxc-interstitial-meeting__media wxc-local-media--no-media"
+          className="wxc wxc-spinner"
+          style={
+            Object {
+              "height": 38,
+              "width": 38,
+            }
+          }
+        />
+      </div>
+      <div
+        className="wxc wxc-remote-media wxc-in-meeting__remote-media-in-meeting"
+      >
+        <div
+          className="wxc wxc-badge wxc-remote-media__connecting-badge"
+          style={Object {}}
         >
           <div
-            className="wxc wxc-avatar"
+            className="wxc wxc-spinner wxc-remote-media__connecting-spinner"
+            style={
+              Object {
+                "height": 16,
+                "width": 16,
+              }
+            }
+          />
+          <span>
+            Connecting
+          </span>
+        </div>
+      </div>
+      <div
+        className="wxc wxc-local-media wxc-in-meeting__local-media-in-meeting wxc-local-media--no-media"
+      >
+        <div
+          className="wxc wxc-avatar"
+        >
+          <div
+            className="wxc-avatar__content"
           >
-            <div
-              className="wxc-avatar__content"
+            <svg
+              className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
+              viewBox="0 0 40 40"
             >
-              <svg
-                className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
-                viewBox="0 0 40 40"
+              <text
+                x="50%"
+                y="50%"
               >
-                <text
-                  x="50%"
-                  y="50%"
-                >
-                  BG
-                </text>
-              </svg>
-              <img
-                alt="avatar"
-                className="wxc-avatar__image"
-                onError={[Function]}
-                src="./images/barbara.png"
-              />
-            </div>
+                BG
+              </text>
+            </svg>
+            <img
+              alt="avatar"
+              className="wxc-avatar__image"
+              onError={[Function]}
+              src="./images/barbara.png"
+            />
           </div>
         </div>
       </div>
@@ -131,10 +107,10 @@ Array [
 ]
 `;
 
-exports[`Storyshots Meetings/Webex Interstitial Meeting Video Enabled 1`] = `
+exports[`Storyshots Meetings/Webex In-Meeting Audio Only 1`] = `
 Array [
   <div
-    className="wxc wxc-interstitial-meeting"
+    className="wxc wxc-in-meeting"
     style={
       Object {
         "height": "100%",
@@ -143,7 +119,7 @@ Array [
     }
   >
     <div
-      className="wxc-interstitial-meeting__media-container"
+      className="wxc-in-meeting__media-container"
       style={
         Object {
           "maxWidth": "none",
@@ -151,45 +127,493 @@ Array [
       }
     >
       <div
-        className="wxc wxc-meeting-info wxc-interstitial-meeting__info"
-      >
-        <h5
-          className="wxc wxc-title wxc-meeting-info__title wxc-title--subsection"
-          style={Object {}}
-        >
-          Interstitial
-        </h5>
-      </div>
-      <div
-        className="wxc-interstitial-meeting__interstitial-media-container"
+        className="wxc wxc-meeting-info wxc-in-meeting__info"
       >
         <div
-          className="wxc wxc-local-media wxc-interstitial-meeting__media wxc-local-media--no-media"
+          className="wxc wxc-spinner"
+          style={
+            Object {
+              "height": 38,
+              "width": 38,
+            }
+          }
+        />
+      </div>
+      <div
+        className="wxc wxc-remote-media wxc-in-meeting__remote-media-in-meeting"
+      >
+        <div
+          className="wxc wxc-badge wxc-remote-media__connecting-badge"
+          style={Object {}}
         >
           <div
-            className="wxc wxc-avatar"
+            className="wxc wxc-spinner wxc-remote-media__connecting-spinner"
+            style={
+              Object {
+                "height": 16,
+                "width": 16,
+              }
+            }
+          />
+          <span>
+            Connecting
+          </span>
+        </div>
+      </div>
+      <div
+        className="wxc wxc-local-media wxc-in-meeting__local-media-in-meeting wxc-local-media--no-media"
+      >
+        <div
+          className="wxc wxc-avatar"
+        >
+          <div
+            className="wxc-avatar__content"
           >
-            <div
-              className="wxc-avatar__content"
+            <svg
+              className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
+              viewBox="0 0 40 40"
             >
-              <svg
-                className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
-                viewBox="0 0 40 40"
+              <text
+                x="50%"
+                y="50%"
               >
-                <text
-                  x="50%"
-                  y="50%"
-                >
-                  BG
-                </text>
-              </svg>
-              <img
-                alt="avatar"
-                className="wxc-avatar__image"
-                onError={[Function]}
-                src="./images/barbara.png"
-              />
-            </div>
+                BG
+              </text>
+            </svg>
+            <img
+              alt="avatar"
+              className="wxc-avatar__image"
+              onError={[Function]}
+              src="./images/barbara.png"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-video"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-meeting.mp4"
+    width="0"
+  />,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-share"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-share.mp4"
+    width="0"
+  />,
+]
+`;
+
+exports[`Storyshots Meetings/Webex In-Meeting Connecting 1`] = `
+Array [
+  <div
+    className="wxc wxc-in-meeting"
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="wxc-in-meeting__media-container"
+      style={
+        Object {
+          "maxWidth": "none",
+        }
+      }
+    >
+      <div
+        className="wxc wxc-meeting-info wxc-in-meeting__info"
+      >
+        <div
+          className="wxc wxc-spinner"
+          style={
+            Object {
+              "height": 38,
+              "width": 38,
+            }
+          }
+        />
+      </div>
+      <div
+        className="wxc wxc-remote-media wxc-in-meeting__remote-media-in-meeting"
+      >
+        <div
+          className="wxc wxc-badge wxc-remote-media__connecting-badge"
+          style={Object {}}
+        >
+          <div
+            className="wxc wxc-spinner wxc-remote-media__connecting-spinner"
+            style={
+              Object {
+                "height": 16,
+                "width": 16,
+              }
+            }
+          />
+          <span>
+            Connecting
+          </span>
+        </div>
+      </div>
+      <div
+        className="wxc wxc-local-media wxc-in-meeting__local-media-in-meeting wxc-local-media--no-media"
+      >
+        <div
+          className="wxc wxc-avatar"
+        >
+          <div
+            className="wxc-avatar__content"
+          >
+            <svg
+              className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
+              viewBox="0 0 40 40"
+            >
+              <text
+                x="50%"
+                y="50%"
+              >
+                BG
+              </text>
+            </svg>
+            <img
+              alt="avatar"
+              className="wxc-avatar__image"
+              onError={[Function]}
+              src="./images/barbara.png"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-video"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-meeting.mp4"
+    width="0"
+  />,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-share"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-share.mp4"
+    width="0"
+  />,
+]
+`;
+
+exports[`Storyshots Meetings/Webex In-Meeting Local Share 1`] = `
+Array [
+  <div
+    className="wxc wxc-in-meeting"
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="wxc-in-meeting__media-container"
+      style={
+        Object {
+          "maxWidth": "none",
+        }
+      }
+    >
+      <div
+        className="wxc wxc-meeting-info wxc-in-meeting__info"
+      >
+        <div
+          className="wxc wxc-spinner"
+          style={
+            Object {
+              "height": 38,
+              "width": 38,
+            }
+          }
+        />
+      </div>
+      <div
+        className="wxc wxc-remote-media wxc-in-meeting__remote-media-in-meeting"
+      >
+        <div
+          className="wxc wxc-badge wxc-remote-media__connecting-badge"
+          style={Object {}}
+        >
+          <div
+            className="wxc wxc-spinner wxc-remote-media__connecting-spinner"
+            style={
+              Object {
+                "height": 16,
+                "width": 16,
+              }
+            }
+          />
+          <span>
+            Connecting
+          </span>
+        </div>
+      </div>
+      <div
+        className="wxc wxc-local-media wxc-in-meeting__local-media-in-meeting wxc-local-media--no-media"
+      >
+        <div
+          className="wxc wxc-avatar"
+        >
+          <div
+            className="wxc-avatar__content"
+          >
+            <svg
+              className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
+              viewBox="0 0 40 40"
+            >
+              <text
+                x="50%"
+                y="50%"
+              >
+                BG
+              </text>
+            </svg>
+            <img
+              alt="avatar"
+              className="wxc-avatar__image"
+              onError={[Function]}
+              src="./images/barbara.png"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-video"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-meeting.mp4"
+    width="0"
+  />,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-share"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-share.mp4"
+    width="0"
+  />,
+]
+`;
+
+exports[`Storyshots Meetings/Webex In-Meeting Remote Share 1`] = `
+Array [
+  <div
+    className="wxc wxc-in-meeting"
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="wxc-in-meeting__media-container"
+      style={
+        Object {
+          "maxWidth": "none",
+        }
+      }
+    >
+      <div
+        className="wxc wxc-meeting-info wxc-in-meeting__info"
+      >
+        <div
+          className="wxc wxc-spinner"
+          style={
+            Object {
+              "height": 38,
+              "width": 38,
+            }
+          }
+        />
+      </div>
+      <div
+        className="wxc wxc-remote-media wxc-in-meeting__remote-media-in-meeting"
+      >
+        <div
+          className="wxc wxc-badge wxc-remote-media__connecting-badge"
+          style={Object {}}
+        >
+          <div
+            className="wxc wxc-spinner wxc-remote-media__connecting-spinner"
+            style={
+              Object {
+                "height": 16,
+                "width": 16,
+              }
+            }
+          />
+          <span>
+            Connecting
+          </span>
+        </div>
+      </div>
+      <div
+        className="wxc wxc-local-media wxc-in-meeting__local-media-in-meeting wxc-local-media--no-media"
+      >
+        <div
+          className="wxc wxc-avatar"
+        >
+          <div
+            className="wxc-avatar__content"
+          >
+            <svg
+              className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
+              viewBox="0 0 40 40"
+            >
+              <text
+                x="50%"
+                y="50%"
+              >
+                BG
+              </text>
+            </svg>
+            <img
+              alt="avatar"
+              className="wxc-avatar__image"
+              onError={[Function]}
+              src="./images/barbara.png"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-video"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-meeting.mp4"
+    width="0"
+  />,
+  <video
+    autoPlay={true}
+    height="0"
+    id="remote-share"
+    loop={true}
+    muted={true}
+    playsInline={true}
+    src="./video/ongoing-share.mp4"
+    width="0"
+  />,
+]
+`;
+
+exports[`Storyshots Meetings/Webex In-Meeting Video Only 1`] = `
+Array [
+  <div
+    className="wxc wxc-in-meeting"
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="wxc-in-meeting__media-container"
+      style={
+        Object {
+          "maxWidth": "none",
+        }
+      }
+    >
+      <div
+        className="wxc wxc-meeting-info wxc-in-meeting__info"
+      >
+        <div
+          className="wxc wxc-spinner"
+          style={
+            Object {
+              "height": 38,
+              "width": 38,
+            }
+          }
+        />
+      </div>
+      <div
+        className="wxc wxc-remote-media wxc-in-meeting__remote-media-in-meeting"
+      >
+        <div
+          className="wxc wxc-badge wxc-remote-media__connecting-badge"
+          style={Object {}}
+        >
+          <div
+            className="wxc wxc-spinner wxc-remote-media__connecting-spinner"
+            style={
+              Object {
+                "height": 16,
+                "width": 16,
+              }
+            }
+          />
+          <span>
+            Connecting
+          </span>
+        </div>
+      </div>
+      <div
+        className="wxc wxc-local-media wxc-in-meeting__local-media-in-meeting wxc-local-media--no-media"
+      >
+        <div
+          className="wxc wxc-avatar"
+        >
+          <div
+            className="wxc-avatar__content"
+          >
+            <svg
+              className="wxc-avatar__placeholder wxc-avatar__placeholder-6"
+              viewBox="0 0 40 40"
+            >
+              <text
+                x="50%"
+                y="50%"
+              >
+                BG
+              </text>
+            </svg>
+            <img
+              alt="avatar"
+              className="wxc-avatar__image"
+              onError={[Function]}
+              src="./images/barbara.png"
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Issue: Meeting Title in in-meeting component is not rendered as per web.webex.com
fix: added info with margin in in-meeting css

screenshot before:
![Web client vs Widget](https://github.com/user-attachments/assets/c02d6a62-0fe4-4b02-a4bc-a384971f7b1b)

screenshot after:
![Screenshot 2024-10-16 at 3 50 31 PM](https://github.com/user-attachments/assets/cba4e41f-5e05-403c-83fe-824a1d092ed5)
