### PR TITLE
fix(webexMember): updated member name handling

### DIFF
--- a/src/components/WebexMember/WebexMember.jsx
+++ b/src/components/WebexMember/WebexMember.jsx
@@ -39,8 +39,8 @@ export default function WebexMember({
   const members = useMembers(destinationID, destinationType);
   const member = members
     .find((itemMember) => itemMember.ID === personID);
+  const memberName = member?.name || displayName;
   const organization = useOrganization(orgID);
-
   const isMuted = member?.muted;
   const isSpeaking = member?.speaking;
   const isExternal = orgID !== undefined && me.orgID !== undefined && me.orgID !== orgID;
@@ -64,7 +64,7 @@ export default function WebexMember({
       <WebexAvatar personID={personID} displayStatus={displayStatus} className={sc('avatar')} />
       <div className={sc('details')}>
         <div className={sc('name')}>
-          {(displayName ?? <Spinner size={18} />) || <i>Name not available</i>}
+          {(memberName ?? <Spinner size={18} />) || <i>Name not available</i>}
           {isGuest && <span className={sc('guest')}> (Guest)</span>}
         </div>
         {roles.length > 0 && <div className={sc('roles')}>{roles.join(', ')}</div>}


### PR DESCRIPTION
## This pull request addresses
Issue:- The user is trying to enter the name according to their wish but whatever the name entered by the user unfortunately it not going to display on the sample app when you click to see in the participants list means it taking the system default name so for this issue the following changes are done
## by making following changes
This PR updates the logic for displaying the member's name in the `WebexMember` component. If the `member.name` is unavailable, it will fall back to the `displayName`. This ensures more consistent name handling within the component.

https://github.com/user-attachments/assets/1c4ad4c7-ea95-4dfc-b98d-74b4b9e48356

### **This below recording for the system default `displayName`** 
when you are not providing the name that means whenever the name field is empty and not provides anything then the display name will system default name

https://github.com/user-attachments/assets/0d3f84af-4170-4fbf-ab07-ab35e8ea0eb8

