### PR TITLE
feat(meetings-widgets): fixed-join-meeting-acc

### DIFF
--- a/src/components/WebexMeetingControl/WebexMeetingControl.jsx
+++ b/src/components/WebexMeetingControl/WebexMeetingControl.jsx
@@ -64,7 +64,7 @@ function renderButton(sc, action, display, style, showText, asItem, autoFocus, t
         size={48}
         isDisabled={isDisabled}
         onClick={action}
-        ariaLabel={hint || text}
+        ariaLabel={text}
         pressed={isActive && type === 'TOGGLE'}
         tooltip={tooltip}
         autoFocus={autoFocus}


### PR DESCRIPTION
### Issue

[SPARK-564413](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564413)

In case of accessibility, when we were over the `Join Meeting` button, it incorrectly said the hint - 'mute, video on' and not the text.

### Fix

* Fixed code to include the text only and not the hint as per instructions from applause

### GIF
![ScreenRecording2024-11-26at4 46 41PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0b1da7c5-94ad-4ad2-84ef-2d130e04410f)


### Vidcast of working of buttons
https://app.vidcast.io/share/ae43d3c3-76ab-4c20-8dc9-47f6fb4e9ce3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Manual Tests

* Checked accessibility with voice over and ensured it aligns with applause requirements.
* Checked meeting behaviour and ensured we can join the meeting.
* Tried mute/unmute and video on/video off and ensured it does not break any functionality in the `Join Meeting` button.
* [Working of all other buttons](https://app.vidcast.io/share/ae43d3c3-76ab-4c20-8dc9-47f6fb4e9ce3)
* All vo is exactly the same as before - only now we have fixed Join Meeting issue.

## Summary by CodeRabbit

- **Accessibility Improvements**
	- Updated the accessibility label for the button in the Webex Meeting Control component to enhance clarity for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->