### PR TITLE
fix(fcc): Leave meeting button accessibility issue.

### DIFF
--- a/src/components/WebexMeetingControl/WebexMeetingControl.jsx
+++ b/src/components/WebexMeetingControl/WebexMeetingControl.jsx
@@ -64,7 +64,7 @@ function renderButton(sc, action, display, style, showText, asItem, autoFocus, t
         size={48}
         isDisabled={isDisabled}
         onClick={action}
-        ariaLabel={text}
+        ariaLabel={text || tooltip}
         pressed={isActive && type === 'TOGGLE'}
         tooltip={tooltip}
         autoFocus={autoFocus}


### PR DESCRIPTION
**Issue:** 

[SPARK-564414](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564414)

In case of accessibility, when we were over the `Leave meeting` button, the screen reader says "undefined, button"

**Fix**

* Fixed code to include the text and as well as tooltip

**Vidcast of testing:**
https://app.vidcast.io/share/5a101376-0ffd-4881-bcd8-2d41c1e746c3


**Manual Tests Performed**
 
* Checked accessibility with voice over and ensured it aligns with applause requirements.
* Checked meeting behaviour and ensured we can join the meeting.
* All voice over is exactly the same as before, the changes is only for "Leave meeting button"
* I have tested mute/unmute and video on/video off and ensured it does not break any functionality in the `Join Meeting` button
* After joining the meeting, I have also tested audio, video, share screen, settings & Leave meeting functionality.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved accessibility of the Webex Meeting Control by updating button labels for better screen reader support. 

- **Bug Fixes**
	- Ensured that the button label falls back to a tooltip if no text is provided, enhancing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->