### PR TITLE
feat(meeting): enable password and name input for widget init

### DIFF
--- a/src/components/WebexMeeting/WebexMeeting.jsx
+++ b/src/components/WebexMeeting/WebexMeeting.jsx
@@ -21,7 +21,7 @@ import WebexSettings from '../WebexSettings/WebexSettings';
 import WebexWaitingForHost from '../WebexWaitingForHost/WebexWaitingForHost';
 import webexComponentClasses from '../helpers';
 import {useElementDimensions, useMeeting, useRef} from '../hooks';
-import {AdapterContext} from '../hooks/contexts';
+import {AdapterContext, MeetingContext} from '../hooks/contexts';
 
 /**
  * Webex Meeting component displays the default Webex meeting experience.
@@ -35,6 +35,8 @@ import {AdapterContext} from '../hooks/contexts';
  * @param {string} props.layout  Layout to apply on remote video
  * @param {JSX.Element} [props.logo]  Logo
  * @param {string} [props.meetingID]  ID of the meeting
+ * @param {string} [props.meetingPasswordOrPin] Password or pin to join the meeting
+ * @param {string} [props.participantName] Name of the participant joining the meeting
  * @param {object} [props.style]  Custom style to apply
  * @returns {object} JSX of the component
  */
@@ -47,6 +49,8 @@ export default function WebexMeeting({
   layout,
   logo,
   meetingID,
+  meetingPasswordOrPin,
+  participantName,
   style,
 }) {
   const {
@@ -67,6 +71,15 @@ export default function WebexMeeting({
   const [showToast, setShowToast] = useState(false);
   const toastTimeoutRef = useRef();
   const [authModal, setAuthModal] = useState('guest');
+  const {setParticipantName, setMeetingPinPasswd} = useContext(MeetingContext);
+
+  if (meetingPasswordOrPin) {
+    setMeetingPinPasswd(meetingPasswordOrPin);
+  }
+
+  if (participantName) {
+    setParticipantName(participantName);
+  }
 
   useEffect(() => {
     if (state && state !== LEFT) {
@@ -130,7 +143,7 @@ export default function WebexMeeting({
             <WebexSettings meetingID={ID} />
           </Modal>
         )}
-        {passwordRequired && state === NOT_JOINED && (
+        {passwordRequired && !meetingPasswordOrPin && state === NOT_JOINED && (
           <Modal
             onClose={() => adapter.meetingsAdapter.clearPasswordRequiredFlag(ID)}
             otherClassName={[sc('authentication')]}
@@ -172,6 +185,8 @@ WebexMeeting.propTypes = {
   layout: PropTypes.string,
   logo: PropTypes.node,
   meetingID: PropTypes.string,
+  meetingPasswordOrPin: PropTypes.string,
+  participantName: PropTypes.string,
   style: PropTypes.shape(),
 };
 
@@ -192,5 +207,7 @@ WebexMeeting.defaultProps = {
   layout: undefined,
   logo: undefined,
   meetingID: undefined,
+  meetingPasswordOrPin: '',
+  participantName: '',
   style: undefined,
 };

--- a/src/components/WebexMeetingControl/WebexMeetingControl.jsx
+++ b/src/components/WebexMeetingControl/WebexMeetingControl.jsx
@@ -131,7 +131,7 @@ function renderDropdown(sc, action, display, style, tabIndex) {
  * @param {boolean} [props.asItem=false]  Render control as an itemin a list
  * @param {boolean} [props.autoFocus=false]  Flag indicating if the control should have autoFocus
  * @param {string} [props.className]  Custom CSS class to apply
- * @param {string} props.meetingID  ID of the meeting
+ * @param {string} [props.meetingID]  ID of the meeting
  * @param {boolean} [props.showText=true]  Flag that indicates whether to display text on control buttons
  * @param {object} [props.style]  Custom style to apply
  * @param {number} props.tabIndex  Value of the tabIndex attribute

--- a/src/components/WebexMeetingProvider/WebexMeetingProvider.jsx
+++ b/src/components/WebexMeetingProvider/WebexMeetingProvider.jsx
@@ -1,0 +1,22 @@
+/* eslint-disable react/forbid-prop-types */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import {MeetingContext} from '../hooks';
+
+/**
+ * Provides a meeting context to the wrapped component.
+ *
+ * @param {object} props  Data passed to the provider
+ * @param {React.Component} props.children  Component children to wrap
+ * @returns {React.Component} Component with access to the meeting context
+ */
+export default function WebexMeetingProvider({children}) {
+    const [meetingPinPasswd, setMeetingPinPasswd] = useState('');
+    const [participantName, setParticipantName] = useState('');
+    return <MeetingContext.Provider value={{meetingPinPasswd, setMeetingPinPasswd, participantName, setParticipantName}}>{children}</MeetingContext.Provider>;
+}
+
+WebexMeetingProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/WebexMeetingProvider/WebexMeetingProvider.test.js
+++ b/src/components/WebexMeetingProvider/WebexMeetingProvider.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import WebexMeetingProvider from './WebexMeetingProvider';
+
+describe('Webex Meeting Provider', () => {
+  test('checks snapshot', () => {
+    const component = TestRenderer.create(
+      <WebexMeetingProvider>
+        <div className="test" />
+      </WebexMeetingProvider>,
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/components/WebexMeetingProvider/__snapshots__/WebexMeetingProvider.test.js.snap
+++ b/src/components/WebexMeetingProvider/__snapshots__/WebexMeetingProvider.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Webex Meeting Provider checks snapshot 1`] = `
+<div
+  className="test"
+/>
+`;

--- a/src/components/hoc/withMeeting.jsx
+++ b/src/components/hoc/withMeeting.jsx
@@ -34,7 +34,7 @@ export default function withMeeting(WrappedComponent) {
     const meeting = useMeetingDestination(meetingDestination);
 
     return <WebexMeetingProvider>
-      <WrappedComponent meeting={meeting} {...props} />;
+      <WrappedComponent meeting={meeting} {...props} />
     </WebexMeetingProvider>    
   }
 

--- a/src/components/hoc/withMeeting.jsx
+++ b/src/components/hoc/withMeeting.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {useMeetingDestination} from '../hooks';
+import WebexMeetingProvider from '../WebexMeetingProvider/WebexMeetingProvider';
 
 /**
  * withMeeting is a higher-order component that takes a component (WrappedComponent)
@@ -32,7 +33,9 @@ export default function withMeeting(WrappedComponent) {
     const {meetingDestination} = props;
     const meeting = useMeetingDestination(meetingDestination);
 
-    return <WrappedComponent meeting={meeting} {...props} />;
+    return <WebexMeetingProvider>
+      <WrappedComponent meeting={meeting} {...props} />;
+    </WebexMeetingProvider>    
   }
 
   WithMeeting.propTypes = {

--- a/src/components/hoc/withMeeting.test.jsx
+++ b/src/components/hoc/withMeeting.test.jsx
@@ -11,10 +11,6 @@ describe('withMeeting', () => {
     const mockUseMeetingDestination = jest.fn();
     const propFunc = jest.fn();
     jest.spyOn(meetingDest, 'default').mockImplementation(mockUseMeetingDestination);
-    // jest.mock('../hooks/useMeetingDestination', () => ({
-    //     __esModule: true,
-    //     default: mockUseMeetingDestination,
-    // }));
 
     function TestComponent({meetingDestination, prop1, prop2}) {
         propFunc(meetingDestination, prop1, prop2);
@@ -43,4 +39,4 @@ describe('withMeeting', () => {
     it('checks for useMeetingDestination call', () => {
         expect(mockUseMeetingDestination).toBeCalledWith('test');
     });
-})
+});

--- a/src/components/hoc/withMeeting.test.jsx
+++ b/src/components/hoc/withMeeting.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {create, act} from 'react-test-renderer';
+import PropTypes from 'prop-types';
+
+import * as meetingDest from '../hooks/useMeetingDestination';
+import withMeeting from './withMeeting';
+
+describe('withMeeting', () => {
+    let testRenderer;
+
+    const mockUseMeetingDestination = jest.fn();
+    const propFunc = jest.fn();
+    jest.spyOn(meetingDest, 'default').mockImplementation(mockUseMeetingDestination);
+    // jest.mock('../hooks/useMeetingDestination', () => ({
+    //     __esModule: true,
+    //     default: mockUseMeetingDestination,
+    // }));
+
+    function TestComponent({meetingDestination, prop1, prop2}) {
+        propFunc(meetingDestination, prop1, prop2);
+        return <div />;
+    }
+
+    TestComponent.propTypes = {
+        meetingDestination: PropTypes.string.isRequired,
+        prop1: PropTypes.string.isRequired,
+        prop2: PropTypes.string.isRequired,
+      };
+    
+    const TestComponentWithMeeting = withMeeting(TestComponent);
+
+    act(() => {
+        global.testRendererAct = act;
+        testRenderer = create(
+          <TestComponentWithMeeting meetingDestination="test" prop1="value1" prop2="value2" />,
+        );
+      });
+
+    it('forwards all props', () => {
+        expect(propFunc).toBeCalledWith("test", "value1", "value2");
+    });
+
+    it('checks for useMeetingDestination call', () => {
+        expect(mockUseMeetingDestination).toBeCalledWith('test');
+    });
+})

--- a/src/components/hooks/useMeetingControl.js
+++ b/src/components/hooks/useMeetingControl.js
@@ -1,6 +1,6 @@
 import {useContext, useEffect, useState} from 'react';
 
-import {AdapterContext} from './contexts';
+import {AdapterContext, MeetingContext} from './contexts';
 
 // TODO: Figure out how to import JS Doc definitions and remove duplication.
 /**
@@ -19,6 +19,7 @@ import {AdapterContext} from './contexts';
  */
 export default function useMeetingControl(type, meetingID) {
   const [display, setDisplay] = useState({});
+  const {meetingPinPasswd, participantName} = useContext(MeetingContext);
   const {meetingsAdapter} = useContext(AdapterContext);
   const controls = meetingsAdapter.meetingControls;
   const control = controls[type];
@@ -45,6 +46,10 @@ export default function useMeetingControl(type, meetingID) {
   }, [meetingID, control]);
 
   return control
-    ? [(value) => control.action(meetingID, value), display]
+    ? [(value) => control.action({
+      meetingID,
+      meetingPasswordOrPin: meetingPinPasswd,
+      participantName,
+    }, value), display]
     : [() => {}, {}];
 }

--- a/src/storyshots.test.js
+++ b/src/storyshots.test.js
@@ -66,7 +66,6 @@ function createNodeMock(element) {
 initStoryshots({
   asyncJest: true,
   test: ({story, context, done}) => {
-    // console.log('sreenara story', story);
     const {render} = story;
     const converter = new Stories2SnapsConverter();
     const snapshotFilename = converter.getSnapshotFileName(context);

--- a/src/storyshots.test.js
+++ b/src/storyshots.test.js
@@ -33,7 +33,9 @@ const mockContextValue = {
   setMeetingPinPasswd: (value) => {
     mockContextValue.meetingPinPasswd = value;
   },
-  setParticipantName: () => mockContextValue.participantName,
+  setParticipantName: (value) => {
+    mockContextValue.participantName = value;
+  },
 };
 
 // Wrap story rendering with context

--- a/src/storyshots.test.js
+++ b/src/storyshots.test.js
@@ -1,5 +1,7 @@
 import initStoryshots, {Stories2SnapsConverter} from '@storybook/addon-storyshots';
 import TestRenderer from 'react-test-renderer';
+import React from 'react';
+import {MeetingContext} from './components/hooks';
 
 // useActivityScroll hook has a half second timeout
 // Mocking as it does not allow tests to complete on time
@@ -24,6 +26,23 @@ jest.mock('./util', () => ({
 
 jest.mock('react-draggable', () => 'Draggable');
 
+// Mock context value
+const mockContextValue = {
+  meetingPinPasswd: '123456',
+  participantName: 'Alice',
+  setMeetingPinPasswd: (value) => {
+    mockContextValue.meetingPinPasswd = value;
+  },
+  setParticipantName: () => mockContextValue.participantName,
+};
+
+// Wrap story rendering with context
+const wrapWithContext = (story) => (
+  <MeetingContext.Provider value={mockContextValue}>
+    {story()}
+  </MeetingContext.Provider>
+);
+
 /**
  * Returns a mock DOM ref object for use of snapshot tests.
  *
@@ -45,6 +64,8 @@ function createNodeMock(element) {
 initStoryshots({
   asyncJest: true,
   test: ({story, context, done}) => {
+    // console.log('sreenara story', story);
+    const {render} = story;
     const converter = new Stories2SnapsConverter();
     const snapshotFilename = converter.getSnapshotFileName(context);
 
@@ -57,7 +78,7 @@ initStoryshots({
     global.testRendererAct = TestRenderer.act;
 
     TestRenderer.act(() => {
-      tree = TestRenderer.create(story.render(), {createNodeMock});
+      tree = TestRenderer.create(wrapWithContext(render), {createNodeMock});
 
       // Because observables are async, execute snapshot tests on next event loop cycle
       setTimeout(() => {


### PR DESCRIPTION
### Summary:
Since we've added the password flow into the Webex Meeting Widget, there is an ask for a developer to pass the meeting password as well as participant name programmatically into the Meeting Widget instead of asking users to enter this once the widget loads up. With this PR, developers will now be able to pass participantName and meetingPasswordOrPin props into the WebexMeetingWidget which will allow users to bypass the authentication and directly land into the Interstitial screen where they can set up audio and video.
Post this, they can directly click "Join Meeting" to start the meeting on the widget.

### Benefits:
This allows developers to programmatically insert the password and name into the widget and avoid having to pass this information to a user in an out-of-band manner.

Check the comments in the code for details on changes.

### Tests:
1. Guest joins meeting from widget without name and password. Prompted for this information before joining the meeting.
2. Guest joins meeting from widget with name and password of the meeting. No prompt and directly lands on interstitial screen, followed by joining the meeting
3. Guest joins meeting from widget with name and host pin of the meeting. No prompt and directly lands on interstitial screen, followed by joining the meeting
4. Registered user joins meeting from widget and is not prompted for password.

Vidcast for test scenarios: https://app.vidcast.io/share/90f8051e-7950-4f79-9d63-670c577f7ea3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for optional meeting password/pin and participant name in Webex Meeting components
	- Introduced a new `WebexMeetingProvider` to manage meeting-related context

- **Bug Fixes**
	- Updated meeting control component to handle optional meeting ID
	- Modified authentication modal rendering logic

- **Tests**
	- Added test coverage for new `WebexMeetingProvider` and `withMeeting` higher-order component
	- Enhanced storyshot testing with context mocking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->