### PR TITLE
Fix: Removed aria-label to label the select menu properly

### DIFF
--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
@@ -49,7 +49,7 @@ export default class SwitchMicrophoneControl extends MeetingControl {
           noOptionsMessage: 'No available microphones',
           options: null,
           selected: null,
-          hint: 'Use arrow keys to navigate between microphone options and hit "Enter" to select.',
+
         });
         observer.complete();
       } else {

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchSpeakerControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchSpeakerControl.js
@@ -55,7 +55,7 @@ export default class SwitchSpeakerControl extends MeetingControl {
           noOptionsMessage: 'No available speakers',
           options: null,
           selected: null,
-          hint: 'Use arrow keys to navigate between speaker options and hit "Enter" to select.',
+
         });
         observer.complete();
       } else {

--- a/src/components/WebexSettings/__snapshots__/WebexSettings.stories.storyshot
+++ b/src/components/WebexSettings/__snapshots__/WebexSettings.stories.storyshot
@@ -78,7 +78,6 @@ Array [
                     aria-controls="wxc-0-options"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-label="Use arrow keys to navigate between speaker options and hit \\"Enter\\" to select."
                     aria-labelledby="wxc-0-label"
                     className="wxc-dropdown__selected-option "
                     id="wxc-0-control"


### PR DESCRIPTION
**Issue:** 
[SPARK-564420]: Screen Readers: Label includes incorrect instructions

**Fix**
Removed the aria-label and used aria-labelledby pointing to the id of the visible label so the select menu is properly labeled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed hints for navigating microphone and speaker options, which may impact user accessibility and experience.
- **Refactor**
  - Revised the speaker options control to update the interactive guidance for keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->