### PR TITLE
fix(accessibility): use expand function in toggleExpanded and remove misleading hint function

### DIFF
--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchMicrophoneControl.js
@@ -49,7 +49,6 @@ export default class SwitchMicrophoneControl extends MeetingControl {
           noOptionsMessage: 'No available microphones',
           options: null,
           selected: null,
-          hint: 'Use arrow keys to navigate between microphone options and hit "Enter" to select.',
         });
         observer.complete();
       } else {

--- a/src/adapters/MeetingsJSONAdapter/controls/SwitchSpeakerControl.js
+++ b/src/adapters/MeetingsJSONAdapter/controls/SwitchSpeakerControl.js
@@ -55,7 +55,6 @@ export default class SwitchSpeakerControl extends MeetingControl {
           noOptionsMessage: 'No available speakers',
           options: null,
           selected: null,
-          hint: 'Use arrow keys to navigate between speaker options and hit "Enter" to select.',
         });
         observer.complete();
       } else {

--- a/src/components/inputs/Dropdown/Dropdown.jsx
+++ b/src/components/inputs/Dropdown/Dropdown.jsx
@@ -56,7 +56,11 @@ export default function Dropdown({
   const expand = (withKey) => setExpanded({withKey});
   const toggleExpanded = (withKey) => {
     if (!disabled) {
-      setExpanded(expanded ? undefined : {withKey});
+      if (expanded) {
+        collapse();
+      } else {
+        expand(withKey);
+      }
     }
   };
 


### PR DESCRIPTION
Main Changes:

Fixed Expansion Handling:
In the original toggleExpanded function, state was being updated directly via setExpanded(...) instead of using the expand(withKey) function. Although expand was defined, it was never actually called, leading to unexpected behavior and making debugging difficult (e.g., logging expand showed undefined).
Now, toggleExpanded properly calls expand(withKey), ensuring that expansion logic remains consistent, centralized, and easier to maintain.

Removed Incorrect Hint Function:
A hint function, which was intended to provide usage guidance, was removed. It was giving incorrect instructions that no longer matched the updated functionality and could potentially confuse future maintainers. Its removal helps streamline the code and reduces noise.

Uploading Untitled.mov…



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal logic for toggling dropdown expansion, making the behavior more explicit without changing user-facing functionality.

- **Style**
  - Removed keyboard navigation hints from microphone and speaker selection controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->